### PR TITLE
feat: add Dockerfile and AGENTS.md for GAAI framework parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+## Agent Personas & Directives
+
+**Audience:** Authoritative guide for AI agents working in this repository.
+
+**Core Mission:**
+- Write high-quality, maintainable, and secure code
+- Adhere to project architectural and stylistic standards
+- Follow TDD (Red/Green/Refactor), DbC, DRY, and Law of Demeter
+
+## Safety & Security
+- NEVER commit API keys, passwords, tokens
+- Use .env files for secrets
+- Review all code for security vulnerabilities
+
+## Python Coding Standards
+- Use logging module, not print()
+- No wildcard imports
+- Catch specific exceptions
+- Use type hints
+- Use ruff for formatting and linting
+
+## Design Principles
+- **TDD**: Write failing test first, make it pass, refactor
+- **DbC**: Validate all inputs with preconditions, check outputs with postconditions
+- **DRY**: Single source of truth for all logic
+- **Law of Demeter**: Only talk to immediate collaborators
+- **Small Functions**: Each function has a single purpose
+- **No Monoliths**: Keep files under 300 lines
+
+## Physics Engine: OpenSim
+- Model format: `.osim` (OpenSim XML)
+- Coordinate convention: Y-up
+- Gravity: (0, -9.80665, 0)
+- Bodies, Joints, and Forces defined in OpenSim XML schema
+- Tests validate XML structure without requiring OpenSim installation
+
+## Testing
+- pytest with coverage >= 80%
+- Property-based testing with hypothesis where appropriate
+- Unit tests for all public functions
+- Integration tests for model building
+
+## Git Workflow
+- Conventional Commits (feat:, fix:, docs:, test:, refactor:, chore:)
+- Branch naming: feat/description, fix/description
+- PRs must pass CI before merge

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# Stage 1: Builder
+FROM python:3.12-slim AS builder
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake git pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir \
+    numpy scipy lxml \
+    pytest pytest-cov pytest-xdist pytest-timeout pytest-mock \
+    ruff mypy hypothesis
+# OpenSim is not pip-installable; install via conda or from source
+# RUN conda install -c opensim-org opensim
+
+# Stage 2: Runtime
+FROM python:3.12-slim AS runtime
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+ARG USER_NAME=athlete
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+RUN groupadd -g ${GROUP_ID} ${USER_NAME} && \
+    useradd -m -u ${USER_ID} -g ${GROUP_ID} -s /bin/bash ${USER_NAME}
+COPY --from=builder /usr/local/lib/python3.12 /usr/local/lib/python3.12
+COPY --from=builder /usr/local/bin /usr/local/bin
+ENV PYTHONPATH="/workspace/src"
+WORKDIR /workspace
+COPY --chown=${USER_NAME}:${USER_NAME} src/ ./src/
+COPY --chown=${USER_NAME}:${USER_NAME} tests/ ./tests/
+COPY --chown=${USER_NAME}:${USER_NAME} pyproject.toml conftest.py ./
+USER ${USER_NAME}
+CMD ["/bin/bash"]
+
+# Stage 3: Training
+FROM runtime AS training
+USER root
+RUN pip install --no-cache-dir gymnasium>=0.29.0 stable-baselines3>=2.0.0
+USER ${USER_NAME}
+CMD ["/bin/bash"]


### PR DESCRIPTION
## Summary
- Adds multi-stage Dockerfile (builder, runtime, training stages) for containerized development and CI
- Adds AGENTS.md with TDD/DbC/DRY/LoD directives for AI agent coding standards
- Brings OpenSim_Models repo infrastructure in line with sibling exercise model repositories

## Test plan
- [ ] Verify all 145 existing tests still pass (confirmed locally)
- [ ] Verify ruff check and ruff format pass (confirmed locally)
- [ ] CI status checks pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)