### PR TITLE
chore(ci): bump actions/upload-artifact from v4 to v7

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Upload Coverage Artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.python }}
           path: coverage.xml


### PR DESCRIPTION
Applies dependabot suggestion. Bumps upload-artifact to v7.