### PR TITLE
fix: critical OpenSim bugs and round-2 quality improvements

### DIFF
--- a/examples/generate_all_models.py
+++ b/examples/generate_all_models.py
@@ -14,25 +14,11 @@ import argparse
 import logging
 from pathlib import Path
 
-from opensim_models.exercises.bench_press.bench_press_model import (
-    build_bench_press_model,
-)
-from opensim_models.exercises.clean_and_jerk.clean_and_jerk_model import (
-    build_clean_and_jerk_model,
-)
-from opensim_models.exercises.deadlift.deadlift_model import build_deadlift_model
-from opensim_models.exercises.snatch.snatch_model import build_snatch_model
-from opensim_models.exercises.squat.squat_model import build_squat_model
+from opensim_models.exercises import EXERCISE_BUILDERS
 
 logger = logging.getLogger(__name__)
 
-_EXERCISES = {
-    "squat": build_squat_model,
-    "bench_press": build_bench_press_model,
-    "deadlift": build_deadlift_model,
-    "snatch": build_snatch_model,
-    "clean_and_jerk": build_clean_and_jerk_model,
-}
+_EXERCISES = EXERCISE_BUILDERS
 
 
 def main() -> None:

--- a/src/opensim_models/__main__.py
+++ b/src/opensim_models/__main__.py
@@ -7,25 +7,11 @@ import logging
 import sys
 from pathlib import Path
 
-from opensim_models.exercises.bench_press.bench_press_model import (
-    build_bench_press_model,
-)
-from opensim_models.exercises.clean_and_jerk.clean_and_jerk_model import (
-    build_clean_and_jerk_model,
-)
-from opensim_models.exercises.deadlift.deadlift_model import build_deadlift_model
-from opensim_models.exercises.snatch.snatch_model import build_snatch_model
-from opensim_models.exercises.squat.squat_model import build_squat_model
+from opensim_models.exercises import EXERCISE_BUILDERS
 
 logger = logging.getLogger(__name__)
 
-_BUILDERS = {
-    "squat": build_squat_model,
-    "bench_press": build_bench_press_model,
-    "deadlift": build_deadlift_model,
-    "snatch": build_snatch_model,
-    "clean_and_jerk": build_clean_and_jerk_model,
-}
+_BUILDERS = EXERCISE_BUILDERS
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -85,7 +71,7 @@ def main(argv: list[str] | None = None) -> None:
     output_path = args.output or Path(f"{args.exercise}.osim")
     output_path.write_text(xml_str, encoding="utf-8")
     logger.info("Wrote %s", output_path)
-    logger.warning("Generated %s (%d bytes)", output_path, len(xml_str))
+    logger.info("Generated %s (%d bytes)", output_path, len(xml_str))
 
 
 if __name__ == "__main__":

--- a/src/opensim_models/exercises/__init__.py
+++ b/src/opensim_models/exercises/__init__.py
@@ -1,1 +1,34 @@
 """Exercise-specific OpenSim model builders."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from opensim_models.exercises.bench_press.bench_press_model import (
+    build_bench_press_model,
+)
+from opensim_models.exercises.clean_and_jerk.clean_and_jerk_model import (
+    build_clean_and_jerk_model,
+)
+from opensim_models.exercises.deadlift.deadlift_model import build_deadlift_model
+from opensim_models.exercises.snatch.snatch_model import build_snatch_model
+from opensim_models.exercises.squat.squat_model import build_squat_model
+
+# Single authoritative registry of all supported exercises.
+# Keys are the CLI exercise names; values are convenience build functions.
+EXERCISE_BUILDERS: dict[str, Callable[..., str]] = {
+    "bench_press": build_bench_press_model,
+    "clean_and_jerk": build_clean_and_jerk_model,
+    "deadlift": build_deadlift_model,
+    "snatch": build_snatch_model,
+    "squat": build_squat_model,
+}
+
+__all__ = [
+    "EXERCISE_BUILDERS",
+    "build_bench_press_model",
+    "build_clean_and_jerk_model",
+    "build_deadlift_model",
+    "build_snatch_model",
+    "build_squat_model",
+]

--- a/src/opensim_models/exercises/base.py
+++ b/src/opensim_models/exercises/base.py
@@ -63,6 +63,24 @@ class ExerciseModelBuilder(ABC):
     def set_initial_pose(self, jointset: ET.Element) -> None:
         """Set default coordinate values for the starting position."""
 
+    def _pre_attach_hook(  # noqa: B027
+        self, bodyset: ET.Element, jointset: ET.Element
+    ) -> None:
+        """Hook called after bodies are built, before barbell is attached.
+
+        Subclasses may override to inject additional bodies or joints
+        (e.g. a bench body and constraint for bench press).
+        The default implementation is a no-op.
+        """
+
+    def _skip_ground_joint(self) -> bool:
+        """Return True if the pelvis–ground FreeJoint should be omitted.
+
+        Override in subclasses that supply their own pelvis parent joint
+        (e.g. bench press, where pelvis is welded to the bench body).
+        """
+        return False
+
     def build(self) -> str:
         """Build the complete OpenSim model XML and return as string.
 
@@ -86,13 +104,21 @@ class ExerciseModelBuilder(ABC):
         bodyset = ET.SubElement(model, "BodySet")
         jointset = ET.SubElement(model, "JointSet")
 
-        # Build body
-        body_bodies = create_full_body(bodyset, jointset, self.config.body_spec)
+        # Build body (skip the ground FreeJoint when subclass requests it)
+        body_bodies = create_full_body(
+            bodyset,
+            jointset,
+            self.config.body_spec,
+            skip_ground_joint=self._skip_ground_joint(),
+        )
 
         # Build barbell
         barbell_bodies = create_barbell_bodies(
             bodyset, jointset, self.config.barbell_spec
         )
+
+        # Subclass hook: inject extra bodies/joints before barbell attachment
+        self._pre_attach_hook(bodyset, jointset)
 
         # Exercise-specific attachment
         self.attach_barbell(jointset, body_bodies, barbell_bodies)

--- a/src/opensim_models/exercises/bench_press/bench_press_model.py
+++ b/src/opensim_models/exercises/bench_press/bench_press_model.py
@@ -21,14 +21,10 @@ import math
 import xml.etree.ElementTree as ET
 
 from opensim_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
-from opensim_models.shared.barbell import create_barbell_bodies
-from opensim_models.shared.body import create_full_body
-from opensim_models.shared.contracts.postconditions import ensure_valid_xml
 from opensim_models.shared.utils.geometry import rectangular_prism_inertia
 from opensim_models.shared.utils.xml_helpers import (
     add_body,
     add_weld_joint,
-    serialize_model,
     set_coordinate_default,
 )
 
@@ -154,6 +150,14 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
             location_in_child=(BENCH_GRIP_HALF_WIDTH, 0, 0),
         )
 
+    def _skip_ground_joint(self) -> bool:
+        """Bench press supplies its own pelvis parent via WeldJoint to bench."""
+        return True
+
+    def _pre_attach_hook(self, bodyset: ET.Element, jointset: ET.Element) -> None:
+        """Inject the bench body and pelvis-to-bench constraint."""
+        self._add_bench_and_constraint(bodyset, jointset)
+
     def set_initial_pose(self, jointset: ET.Element) -> None:
         """Set supine lockout position.
 
@@ -163,42 +167,6 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
         shoulder_flex = 1.5708  # ~90 degrees (arms vertical)
         for side in ("l", "r"):
             set_coordinate_default(jointset, f"shoulder_{side}_flex", shoulder_flex)
-
-    def build(self) -> str:
-        """Build the complete bench press OpenSim model XML string.
-
-        Extends the base build() to inject the bench body and the
-        pelvis-to-bench weld constraint before serialisation.
-        """
-        root = ET.Element("OpenSimDocument", Version="40500")
-        model = ET.SubElement(root, "Model", name=self.exercise_name)
-
-        gravity = ET.SubElement(model, "gravity")
-        g = self.config.gravity
-        gravity.text = f"{g[0]:.6f} {g[1]:.6f} {g[2]:.6f}"
-
-        ground_el = ET.SubElement(model, "Ground", name="ground")
-        ET.SubElement(ground_el, "mass").text = "0"
-        ET.SubElement(ground_el, "mass_center").text = "0 0 0"
-        ET.SubElement(ground_el, "inertia").text = "0 0 0 0 0 0"
-
-        bodyset = ET.SubElement(model, "BodySet")
-        jointset = ET.SubElement(model, "JointSet")
-
-        body_bodies = create_full_body(bodyset, jointset, self.config.body_spec)
-        barbell_bodies = create_barbell_bodies(
-            bodyset, jointset, self.config.barbell_spec
-        )
-
-        # Add bench body and pelvis constraint (bench-press specific)
-        self._add_bench_and_constraint(bodyset, jointset)
-
-        self.attach_barbell(jointset, body_bodies, barbell_bodies)
-        self.set_initial_pose(jointset)
-
-        xml_str = serialize_model(root)
-        ensure_valid_xml(xml_str)
-        return xml_str
 
 
 def build_bench_press_model(

--- a/src/opensim_models/exercises/clean_and_jerk/clean_and_jerk_model.py
+++ b/src/opensim_models/exercises/clean_and_jerk/clean_and_jerk_model.py
@@ -30,6 +30,12 @@ from __future__ import annotations
 import xml.etree.ElementTree as ET
 
 from opensim_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
+from opensim_models.exercises.constants import (
+    _CLEAN_GRIP_HALF_WIDTH,
+    _FLOOR_PULL_HIP_ANGLE,
+    _FLOOR_PULL_KNEE_ANGLE,
+    _FLOOR_PULL_LUMBAR_ANGLE,
+)
 from opensim_models.shared.utils.xml_helpers import (
     add_weld_joint,
     set_coordinate_default,
@@ -60,15 +66,13 @@ class CleanAndJerkModelBuilder(ExerciseModelBuilder):
 
         Clean grip: approximately shoulder width, ~0.25 m from shaft center.
         """
-        grip_offset = 0.25
-
         add_weld_joint(
             jointset,
             name="barbell_to_left_hand",
             parent_body="hand_l",
             child_body="barbell_shaft",
             location_in_parent=(0, 0, 0),
-            location_in_child=(-grip_offset, 0, 0),
+            location_in_child=(-_CLEAN_GRIP_HALF_WIDTH, 0, 0),
         )
 
         add_weld_joint(
@@ -77,18 +81,17 @@ class CleanAndJerkModelBuilder(ExerciseModelBuilder):
             parent_body="hand_r",
             child_body="barbell_shaft",
             location_in_parent=(0, 0, 0),
-            location_in_child=(grip_offset, 0, 0),
+            location_in_child=(_CLEAN_GRIP_HALF_WIDTH, 0, 0),
         )
 
     def set_initial_pose(self, jointset: ET.Element) -> None:
         """Set starting position: bar on floor, clean grip, hip hinge."""
-        hip_flex = 1.3963  # ~80 degrees (same as deadlift start)
-        knee_flex = -1.0472  # ~60 degrees
-        lumbar_flex = 0.5236  # ~30 degrees forward lean
         for side in ("l", "r"):
-            set_coordinate_default(jointset, f"hip_{side}_flex", hip_flex)
-            set_coordinate_default(jointset, f"knee_{side}_flex", knee_flex)
-        set_coordinate_default(jointset, "lumbar_flex", lumbar_flex)
+            set_coordinate_default(jointset, f"hip_{side}_flex", _FLOOR_PULL_HIP_ANGLE)
+            set_coordinate_default(
+                jointset, f"knee_{side}_flex", _FLOOR_PULL_KNEE_ANGLE
+            )
+        set_coordinate_default(jointset, "lumbar_flex", _FLOOR_PULL_LUMBAR_ANGLE)
 
 
 def build_clean_and_jerk_model(

--- a/src/opensim_models/exercises/constants.py
+++ b/src/opensim_models/exercises/constants.py
@@ -1,0 +1,17 @@
+"""Shared biomechanical constants for barbell exercise models.
+
+Floor-pull exercises (deadlift, snatch, clean-and-jerk) all start with the
+bar on the floor and share the same approximate initial joint angles.
+"""
+
+from __future__ import annotations
+
+# Initial joint angles for floor-pull exercises (bar starting on the ground).
+# Values match standard competitive starting positions.
+_FLOOR_PULL_HIP_ANGLE: float = 1.3963  # ~80° hip flexion
+_FLOOR_PULL_KNEE_ANGLE: float = -1.0472  # ~60° knee flexion (negative convention)
+_FLOOR_PULL_LUMBAR_ANGLE: float = 0.5236  # ~30° lumbar flexion
+
+# Grip offsets from shaft centre (metres) for each exercise.
+_SNATCH_GRIP_HALF_WIDTH: float = 0.58  # Wide snatch grip (~1.5× shoulder width)
+_CLEAN_GRIP_HALF_WIDTH: float = 0.25  # Shoulder-width clean grip

--- a/src/opensim_models/exercises/deadlift/deadlift_model.py
+++ b/src/opensim_models/exercises/deadlift/deadlift_model.py
@@ -22,6 +22,11 @@ import warnings
 import xml.etree.ElementTree as ET
 
 from opensim_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
+from opensim_models.exercises.constants import (
+    _FLOOR_PULL_HIP_ANGLE,
+    _FLOOR_PULL_KNEE_ANGLE,
+    _FLOOR_PULL_LUMBAR_ANGLE,
+)
 from opensim_models.shared.utils.xml_helpers import (
     add_weld_joint,
     set_coordinate_default,
@@ -30,10 +35,11 @@ from opensim_models.shared.utils.xml_helpers import (
 PLATE_RADIUS = 0.225  # Standard 450mm diameter plate radius
 _DEADLIFT_GRIP_HALF_WIDTH = 0.22  # metres from shaft center to each hand
 
-# Named angle constants for use in feasibility check
-DEADLIFT_INITIAL_HIP_ANGLE: float = 1.3963  # ~80 degrees hip flexion
-DEADLIFT_INITIAL_KNEE_ANGLE: float = -1.0472  # ~60 degrees knee flexion (negative)
-DEADLIFT_INITIAL_LUMBAR_ANGLE: float = 0.5236  # ~30 degrees lumbar flexion
+# Re-export shared constants under the original public names for backwards
+# compatibility and use within this module.
+DEADLIFT_INITIAL_HIP_ANGLE: float = _FLOOR_PULL_HIP_ANGLE
+DEADLIFT_INITIAL_KNEE_ANGLE: float = _FLOOR_PULL_KNEE_ANGLE
+DEADLIFT_INITIAL_LUMBAR_ANGLE: float = _FLOOR_PULL_LUMBAR_ANGLE
 
 
 class DeadliftModelBuilder(ExerciseModelBuilder):
@@ -50,7 +56,11 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
         return "deadlift"
 
     def _check_pose_feasibility(self) -> None:
-        """Warn if the initial pose likely places hands far from barbell height."""
+        """Warn if the initial pose likely places hands far from barbell height.
+
+        Note: variable names use the ``_y`` suffix because OpenSim uses a
+        Y-up coordinate system (gravity acts in the -Y direction).
+        """
         h = self.config.body_spec.height
         # Approx Winter (2009) fractions
         shank = h * 0.246
@@ -59,15 +69,15 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
         upper_arm = h * 0.186
         forearm = h * 0.146
 
-        knee_z = shank * math.cos(abs(DEADLIFT_INITIAL_KNEE_ANGLE))
-        hip_z = knee_z + thigh * math.cos(abs(DEADLIFT_INITIAL_HIP_ANGLE))
-        torso_top_z = hip_z + torso * math.cos(abs(DEADLIFT_INITIAL_LUMBAR_ANGLE))
-        hand_z = torso_top_z - upper_arm - forearm
+        knee_y = shank * math.cos(abs(DEADLIFT_INITIAL_KNEE_ANGLE))
+        hip_y = knee_y + thigh * math.cos(abs(DEADLIFT_INITIAL_HIP_ANGLE))
+        torso_top_y = hip_y + torso * math.cos(abs(DEADLIFT_INITIAL_LUMBAR_ANGLE))
+        hand_y = torso_top_y - upper_arm - forearm
 
-        if abs(hand_z - PLATE_RADIUS) > 0.15:
+        if abs(hand_y - PLATE_RADIUS) > 0.15:
             warnings.warn(
-                f"Deadlift initial pose: estimated hand height {hand_z:.3f} m differs from "
-                f"bar height {PLATE_RADIUS:.3f} m by {abs(hand_z - PLATE_RADIUS):.3f} m. "
+                f"Deadlift initial pose: estimated hand height {hand_y:.3f} m differs from "
+                f"bar height {PLATE_RADIUS:.3f} m by {abs(hand_y - PLATE_RADIUS):.3f} m. "
                 f"Consider adjusting DEADLIFT_INITIAL_* angles.",
                 stacklevel=3,
             )

--- a/src/opensim_models/exercises/snatch/snatch_model.py
+++ b/src/opensim_models/exercises/snatch/snatch_model.py
@@ -26,6 +26,12 @@ from __future__ import annotations
 import xml.etree.ElementTree as ET
 
 from opensim_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
+from opensim_models.exercises.constants import (
+    _FLOOR_PULL_HIP_ANGLE,
+    _FLOOR_PULL_KNEE_ANGLE,
+    _FLOOR_PULL_LUMBAR_ANGLE,
+    _SNATCH_GRIP_HALF_WIDTH,
+)
 from opensim_models.shared.utils.xml_helpers import (
     add_weld_joint,
     set_coordinate_default,
@@ -53,15 +59,13 @@ class SnatchModelBuilder(ExerciseModelBuilder):
         Snatch grip is approximately 0.55-0.60 m from shaft center
         on each side (~1.5x shoulder width).
         """
-        grip_offset = 0.58  # wide snatch grip
-
         add_weld_joint(
             jointset,
             name="barbell_to_left_hand",
             parent_body="hand_l",
             child_body="barbell_shaft",
             location_in_parent=(0, 0, 0),
-            location_in_child=(-grip_offset, 0, 0),
+            location_in_child=(-_SNATCH_GRIP_HALF_WIDTH, 0, 0),
         )
 
         add_weld_joint(
@@ -70,18 +74,17 @@ class SnatchModelBuilder(ExerciseModelBuilder):
             parent_body="hand_r",
             child_body="barbell_shaft",
             location_in_parent=(0, 0, 0),
-            location_in_child=(grip_offset, 0, 0),
+            location_in_child=(_SNATCH_GRIP_HALF_WIDTH, 0, 0),
         )
 
     def set_initial_pose(self, jointset: ET.Element) -> None:
         """Set starting position: bar on floor, wide grip, deep hip hinge."""
-        hip_flex = 1.3963  # ~80 degrees (same as deadlift start)
-        knee_flex = -1.0472  # ~60 degrees
-        lumbar_flex = 0.5236  # ~30 degrees forward lean
         for side in ("l", "r"):
-            set_coordinate_default(jointset, f"hip_{side}_flex", hip_flex)
-            set_coordinate_default(jointset, f"knee_{side}_flex", knee_flex)
-        set_coordinate_default(jointset, "lumbar_flex", lumbar_flex)
+            set_coordinate_default(jointset, f"hip_{side}_flex", _FLOOR_PULL_HIP_ANGLE)
+            set_coordinate_default(
+                jointset, f"knee_{side}_flex", _FLOOR_PULL_KNEE_ANGLE
+            )
+        set_coordinate_default(jointset, "lumbar_flex", _FLOOR_PULL_LUMBAR_ANGLE)
 
 
 def build_snatch_model(
@@ -91,7 +94,7 @@ def build_snatch_model(
 ) -> str:
     """Convenience function to build a snatch model XML string.
 
-    Default: 80 kg person, 120 kg total barbell (competitive 96 kg class).
+    Default: 80 kg person, 100 kg total barbell (20 kg bar + 2 × 40 kg plates).
     """
     from opensim_models.shared.barbell import BarbellSpec
     from opensim_models.shared.body import BodyModelSpec

--- a/src/opensim_models/shared/barbell/barbell_model.py
+++ b/src/opensim_models/shared/barbell/barbell_model.py
@@ -65,6 +65,11 @@ class BarbellSpec:
                 f"shaft_length ({self.shaft_length}) must be < "
                 f"total_length ({self.total_length})"
             )
+        if self.sleeve_inner_radius >= self.sleeve_radius:
+            raise ValueError(
+                f"sleeve_inner_radius ({self.sleeve_inner_radius}) must be < "
+                f"sleeve_radius ({self.sleeve_radius})"
+            )
 
     @property
     def sleeve_length(self) -> float:

--- a/src/opensim_models/shared/body/body_model.py
+++ b/src/opensim_models/shared/body/body_model.py
@@ -47,6 +47,12 @@ logger = logging.getLogger(__name__)
 
 _TISSUE_DENSITY_KG_M3: float = 1000.0  # Average human tissue ~1000 kg/m³
 
+# Segment names that are themselves bilateral (have _l/_r variants).
+# Used to determine whether a child segment's parent link needs a side suffix.
+_BILATERAL_SEGMENTS: frozenset[str] = frozenset(
+    {"upper_arm", "forearm", "thigh", "shank"}
+)
+
 
 def _segment_radius_from_mass(mass: float, length: float) -> float:
     """Compute cylinder radius from mass and length assuming uniform tissue density.
@@ -130,7 +136,9 @@ def _add_bilateral_limb(
         add_pin_joint(
             jointset,
             name=f"{coord_prefix}_{side}",
-            parent_body=f"{parent_name}_{side}" if "_" in parent_name else parent_name,
+            parent_body=f"{parent_name}_{side}"
+            if parent_name in _BILATERAL_SEGMENTS
+            else parent_name,
             child_body=body_name,
             location_in_parent=(sign * parent_lateral_x, parent_offset_y, 0),
             location_in_child=(0, 0, 0),
@@ -144,8 +152,19 @@ def create_full_body(
     bodyset: ET.Element,
     jointset: ET.Element,
     spec: BodyModelSpec | None = None,
+    *,
+    skip_ground_joint: bool = False,
 ) -> dict[str, ET.Element]:
     """Build the full-body model and append bodies/joints to the given sets.
+
+    Args:
+        bodyset: XML element to append Body elements to.
+        jointset: XML element to append Joint elements to.
+        spec: Anthropometric specification (defaults to 50th-percentile male).
+        skip_ground_joint: When True, the FreeJoint connecting pelvis to ground
+            is omitted. Use this when another mechanism (e.g. a WeldJoint from
+            a bench body) provides the pelvis parent joint, so the body is not
+            over-constrained.
 
     Returns dict of body name -> ET.Element for all created bodies.
     """
@@ -178,13 +197,14 @@ def create_full_body(
     _, foot_len, _ = _seg(spec, "foot")
     pelvis_height = thigh_len + shank_len + foot_len + p_len / 2.0
     logger.debug("Derived pelvis height: %.4f m", pelvis_height)
-    add_free_joint(
-        jointset,
-        name="ground_pelvis",
-        parent_body="ground",
-        child_body="pelvis",
-        location_in_parent=(0, pelvis_height, 0),
-    )
+    if not skip_ground_joint:
+        add_free_joint(
+            jointset,
+            name="ground_pelvis",
+            parent_body="ground",
+            child_body="pelvis",
+            location_in_parent=(0, pelvis_height, 0),
+        )
 
     # --- Torso ---
     t_mass, t_len, t_rad = _seg(spec, "torso")
@@ -207,7 +227,7 @@ def create_full_body(
         location_in_child=(0, 0, 0),
         coord_name="lumbar_flex",
         range_min=-0.5236,
-        range_max=0.7854,
+        range_max=1.0472,  # ~60° — lower end of clinical range (60–80°)
     )
 
     # --- Head ---
@@ -319,8 +339,8 @@ def create_full_body(
         parent_offset_y=-sh_len,
         parent_lateral_x=0,
         coord_prefix="ankle",
-        range_min=-0.7854,
-        range_max=0.7854,
+        range_min=-0.8727,  # ~-50° plantarflexion (physiological max)
+        range_max=0.3491,  # ~+20° dorsiflexion (physiological max)
     )
 
     logger.info("Full-body model complete: %d bodies created", len(bodies))

--- a/src/opensim_models/shared/utils/xml_helpers.py
+++ b/src/opensim_models/shared/utils/xml_helpers.py
@@ -37,8 +37,8 @@ def add_body(
     ET.SubElement(body, "mass").text = f"{mass:.6f}"
     ET.SubElement(body, "mass_center").text = vec3_str(*mass_center)
     ET.SubElement(body, "inertia").text = (
-        f"{inertia_xx:.6f} {inertia_xy:.6f} {inertia_xz:.6f} "
-        f"{inertia_yy:.6f} {inertia_yz:.6f} {inertia_zz:.6f}"
+        f"{inertia_xx:.6f} {inertia_yy:.6f} {inertia_zz:.6f} "
+        f"{inertia_xy:.6f} {inertia_xz:.6f} {inertia_yz:.6f}"
     )
     return body
 
@@ -146,6 +146,9 @@ def set_coordinate_default(jointset: ET.Element, coord_name: str, value: float) 
 
     Searches all joints for a Coordinate element whose 'name' attribute matches
     *coord_name* and updates its default_value text.
+
+    Raises:
+        ValueError: If *coord_name* is not found in any joint in the JointSet.
     """
     for coord in jointset.iter("Coordinate"):
         if coord.get("name") == coord_name:
@@ -153,6 +156,7 @@ def set_coordinate_default(jointset: ET.Element, coord_name: str, value: float) 
             if dv is not None:
                 dv.text = f"{value:.6f}"
             return
+    raise ValueError(f"Coordinate {coord_name!r} not found in jointset")
 
 
 def indent_xml(elem: ET.Element, level: int = 0) -> None:


### PR DESCRIPTION
## Summary

- **CRITICAL (issues #33, #34, #35)**: Fix three bugs that cause every generated `.osim` file to be unloadable by OpenSim 4.x:
  - Inertia tensor was written in wrong column order (`Ixx Ixy Ixz Iyy Iyz Izz` → correct `Ixx Iyy Izz Ixy Ixz Iyz`), leaving Iyy=Izz=0 in all bodies
  - Bilateral limb parent lookup used `'_' in parent_name` heuristic, causing `hand_l/r`, `shank_l/r`, `foot_l/r` to reference non-existent bodies (`forearm`, `thigh`, `shank`) instead of their lateralised counterparts — replaced with explicit `_BILATERAL_SEGMENTS` frozenset
  - Bench press pelvis had two parent joints (FreeJoint from ground + WeldJoint from bench) — fixed via `skip_ground_joint` parameter to `create_full_body` and `_skip_ground_joint()` hook on the builder
- **HIGH (issues #36, #37, #38)**:
  - `BenchPressModelBuilder.build()` duplicated 35+ lines from base class — removed via `_pre_attach_hook` / `_skip_ground_joint` hooks
  - `set_coordinate_default` now raises `ValueError` on unknown coordinate name instead of silently doing nothing
  - Extracted shared `_FLOOR_PULL_*` angle constants to `exercises/constants.py`; snatch and clean_and_jerk import them instead of copy-pasting literals. Fixed misleading `knee_z`/`hip_z` variable names (OpenSim is Y-up). Fixed snatch docstring (was "120 kg", now correct "100 kg"). Added named grip constants
- **MEDIUM (issue #39)**:
  - `BarbellSpec` now validates `sleeve_inner_radius < sleeve_radius`
  - Ankle ROM updated to physiological range (-50°/+20°) from the previous ±45°
  - Lumbar flexion max updated to 60° (was 45°, below clinical range)
  - `logger.warning()` → `logger.info()` for success output in `__main__.py`
  - Deduplicated `_BUILDERS`/`_EXERCISES` registry into single `EXERCISE_BUILDERS` dict in `exercises/__init__.py`

## Closes

Issues #33, #34, #35, #36, #37, #38, #39

## Test plan

- [x] All 217 existing tests pass (`pytest tests/ -x -q`)
- [x] `ruff check src/ tests/` passes with no errors
- [x] `ruff format src/ tests/` applied cleanly
- [ ] Manually load a generated `.osim` in OpenSim GUI to verify inertia tensor and joint topology

🤖 Generated with [Claude Code](https://claude.com/claude-code)