### PR TITLE
Fix barbell inertia axis mismatch and reduce lumbar angle

### DIFF
--- a/src/opensim_models/exercises/constants.py
+++ b/src/opensim_models/exercises/constants.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 # Values match standard competitive starting positions.
 _FLOOR_PULL_HIP_ANGLE: float = 1.3963  # ~80° hip flexion
 _FLOOR_PULL_KNEE_ANGLE: float = -1.0472  # ~60° knee flexion (negative convention)
-_FLOOR_PULL_LUMBAR_ANGLE: float = 0.5236  # ~30° lumbar flexion
+_FLOOR_PULL_LUMBAR_ANGLE: float = 0.2618  # ~15° lumbar flexion
 
 # Grip offsets from shaft centre (metres) for each exercise.
 _SNATCH_GRIP_HALF_WIDTH: float = 0.58  # Wide snatch grip (~1.5× shoulder width)

--- a/src/opensim_models/shared/barbell/barbell_model.py
+++ b/src/opensim_models/shared/barbell/barbell_model.py
@@ -24,8 +24,8 @@ from opensim_models.shared.contracts.preconditions import (
     require_positive,
 )
 from opensim_models.shared.utils.geometry import (
-    cylinder_inertia,
-    hollow_cylinder_inertia,
+    cylinder_inertia_along_x,
+    hollow_cylinder_inertia_along_x,
 )
 from opensim_models.shared.utils.xml_helpers import (
     add_body,
@@ -134,12 +134,12 @@ def create_barbell_bodies(
     symmetrically along the X-axis (left = -X, right = +X).
     """
     logger.info("Creating barbell: %.1f kg total", spec.total_mass)
-    shaft_inertia = cylinder_inertia(
+    shaft_inertia = cylinder_inertia_along_x(
         spec.shaft_mass, spec.shaft_radius, spec.shaft_length
     )
 
-    # Compute inertia for bare sleeve
-    sleeve_inertia = hollow_cylinder_inertia(
+    # Compute inertia for bare sleeve (axis along X)
+    sleeve_inertia = hollow_cylinder_inertia_along_x(
         spec.sleeve_mass,
         inner_radius=spec.sleeve_inner_radius,
         outer_radius=spec.sleeve_radius,
@@ -148,7 +148,7 @@ def create_barbell_bodies(
 
     if spec.plate_mass_per_side > 0:
         # Standard plate radius is 0.225m (450mm diameter)
-        plate_inertia = hollow_cylinder_inertia(
+        plate_inertia = hollow_cylinder_inertia_along_x(
             spec.plate_mass_per_side,
             inner_radius=spec.sleeve_radius,
             outer_radius=0.225,

--- a/src/opensim_models/shared/utils/geometry.py
+++ b/src/opensim_models/shared/utils/geometry.py
@@ -40,6 +40,61 @@ def cylinder_inertia(
     return (ixx, iyy, izz)
 
 
+def cylinder_inertia_along_x(
+    mass: float, radius: float, length: float
+) -> tuple[float, float, float]:
+    """Compute principal inertias (Ixx, Iyy, Izz) for a solid cylinder along X.
+
+    The cylinder axis is aligned with the X-axis (barbell shaft convention).
+
+    Returns (Ixx, Iyy, Izz) where Ixx is the axial moment.
+    """
+    require_positive(mass, "mass")
+    require_positive(radius, "radius")
+    require_positive(length, "length")
+
+    # Axial (about X)
+    ixx = 0.5 * mass * radius**2
+    # Transverse (about Y and Z)
+    iyy = izz = (1.0 / 12.0) * mass * (3.0 * radius**2 + length**2)
+
+    ensure_positive_definite_inertia(ixx, iyy, izz, "cylinder_along_x")
+    return (ixx, iyy, izz)
+
+
+def hollow_cylinder_inertia_along_x(
+    mass: float,
+    inner_radius: float,
+    outer_radius: float,
+    length: float,
+) -> tuple[float, float, float]:
+    """Inertia tensor for a hollow cylinder with axis along X.
+
+    Returns (ixx, iyy, izz) where ixx is axial moment, iyy=izz are transverse.
+
+    Args:
+        mass: Total mass in kg
+        inner_radius: Inner bore radius in metres
+        outer_radius: Outer radius in metres
+        length: Length in metres
+    """
+    require_positive(mass, "mass")
+    require_positive(inner_radius, "inner_radius")
+    require_positive(outer_radius, "outer_radius")
+    require_positive(length, "length")
+    if inner_radius >= outer_radius:
+        raise ValueError(
+            f"inner_radius ({inner_radius:.4f}) must be less than "
+            f"outer_radius ({outer_radius:.4f})"
+        )
+    r_sq_sum = inner_radius**2 + outer_radius**2
+    ixx = 0.5 * mass * r_sq_sum  # axial
+    iyy = izz = (1.0 / 12.0) * mass * (3.0 * r_sq_sum + length**2)  # transverse
+
+    ensure_positive_definite_inertia(ixx, iyy, izz, "hollow_cylinder_along_x")
+    return ixx, iyy, izz
+
+
 def rectangular_prism_inertia(
     mass: float, width: float, height: float, depth: float
 ) -> tuple[float, float, float]:

--- a/tests/unit/shared/test_geometry.py
+++ b/tests/unit/shared/test_geometry.py
@@ -7,7 +7,9 @@ import pytest
 
 from opensim_models.shared.utils.geometry import (
     cylinder_inertia,
+    cylinder_inertia_along_x,
     hollow_cylinder_inertia,
+    hollow_cylinder_inertia_along_x,
     parallel_axis_shift,
     rectangular_prism_inertia,
     rotation_matrix_x,
@@ -73,6 +75,42 @@ class TestHollowCylinderInertia:
     def test_rejects_negative_length(self):
         with pytest.raises(ValueError, match="must be positive"):
             hollow_cylinder_inertia(1.0, 0.025, 0.029, -0.1)
+
+
+class TestCylinderInertiaAlongX:
+    def test_known_values(self):
+        """1 kg cylinder, r=0.1 m, L=1.0 m, axis along X."""
+        ixx, iyy, izz = cylinder_inertia_along_x(1.0, 0.1, 1.0)
+        assert ixx == pytest.approx(0.5 * 1.0 * 0.1**2)
+        assert iyy == pytest.approx((1.0 / 12.0) * (3 * 0.01 + 1.0))
+        assert izz == pytest.approx(iyy)
+
+    def test_axes_swapped_vs_along_y(self):
+        """Ixx along X should equal Iyy along Y (same axial moment)."""
+        _, iyy_y, _ = cylinder_inertia(2.0, 0.05, 0.5)
+        ixx_x, _, _ = cylinder_inertia_along_x(2.0, 0.05, 0.5)
+        assert ixx_x == pytest.approx(iyy_y)
+
+    def test_symmetry(self):
+        """Iyy should equal Izz for a cylinder aligned along X."""
+        _, iyy, izz = cylinder_inertia_along_x(5.0, 0.05, 2.0)
+        assert iyy == pytest.approx(izz)
+
+
+class TestHollowCylinderInertiaAlongX:
+    def test_known_values(self):
+        """Olympic barbell sleeve along X axis."""
+        ixx, iyy, izz = hollow_cylinder_inertia_along_x(1.0, 0.025, 0.029, 0.445)
+        r_sq_sum = 0.025**2 + 0.029**2
+        assert ixx == pytest.approx(0.5 * 1.0 * r_sq_sum)
+        assert iyy == pytest.approx((1.0 / 12.0) * (3.0 * r_sq_sum + 0.445**2))
+        assert izz == pytest.approx(iyy)
+
+    def test_axes_swapped_vs_along_y(self):
+        """Ixx along X should equal Iyy along Y."""
+        _, iyy_y, _ = hollow_cylinder_inertia(2.0, 0.01, 0.05, 0.30)
+        ixx_x, _, _ = hollow_cylinder_inertia_along_x(2.0, 0.01, 0.05, 0.30)
+        assert ixx_x == pytest.approx(iyy_y)
 
 
 class TestRectangularPrismInertia:


### PR DESCRIPTION
## Summary
- Add `cylinder_inertia_along_x()` and `hollow_cylinder_inertia_along_x()` functions for barbell components extending along X-axis, fixing axis mismatch where axial moment was incorrectly computed about Y
- Update `barbell_model.py` to use the new X-axis aligned inertia functions for shaft and sleeve components
- Reduce floor-pull lumbar flexion angle from 30 deg to 15 deg for biomechanically safer starting position

Closes #56, closes #57

## Test plan
- [x] Added unit tests for `cylinder_inertia_along_x` (known values, axis swap equivalence, symmetry)
- [x] Added unit tests for `hollow_cylinder_inertia_along_x` (known values, axis swap equivalence)
- [x] All 220 existing tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)