### PR TITLE
feat: multi-DOF joint upgrades for biomechanical accuracy

### DIFF
--- a/.ci_trigger.py
+++ b/.ci_trigger.py
@@ -1,0 +1,2 @@
+
+# trigger CI

--- a/docs/assessments/initial_assessment.md
+++ b/docs/assessments/initial_assessment.md
@@ -9,9 +9,9 @@
 ## Repository Overview
 
 **Codebase Size:**
-- Source: ~1848 lines across 29 Python files
-- Tests: ~1397 lines across 26 test files
-- Test Ratio: 75%
+- Source: ~2172 lines across 31 Python files
+- Tests: ~1434 lines across 26 test files
+- Test Ratio: 66%
 
 ---
 
@@ -24,7 +24,7 @@
 - `README.md` present: True
 
 ### C - Testing: B
-- Test coverage ratio: 75%
+- Test coverage ratio: 66%
 
 ### D - Security: A
 - Checked via AST, no obvious hardcoded keys.

--- a/src/opensim_models/exercises/bench_press/bench_press_model.py
+++ b/src/opensim_models/exercises/bench_press/bench_press_model.py
@@ -161,11 +161,15 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
         """Set supine lockout position.
 
         Shoulders flexed ~90 deg (arms pointing up), elbows near-extended.
-        The supine orientation is enforced by the bench–pelvis weld constraint.
+        Shoulder adduction set for bench grip width.
+        The supine orientation is enforced by the bench-pelvis weld constraint.
         """
         shoulder_flex = 1.5708  # ~90 degrees (arms vertical)
+        shoulder_adduct = -0.5236  # ~-30° (arms abducted from midline)
         for side in ("l", "r"):
             set_coordinate_default(jointset, f"shoulder_{side}_flex", shoulder_flex)
+            set_coordinate_default(jointset, f"shoulder_{side}_adduct", shoulder_adduct)
+            set_coordinate_default(jointset, f"shoulder_{side}_rotate", 0.0)
 
 
 def build_bench_press_model(

--- a/src/opensim_models/exercises/clean_and_jerk/clean_and_jerk_model.py
+++ b/src/opensim_models/exercises/clean_and_jerk/clean_and_jerk_model.py
@@ -85,9 +85,14 @@ class CleanAndJerkModelBuilder(ExerciseModelBuilder):
         )
 
     def set_initial_pose(self, jointset: ET.Element) -> None:
-        """Set starting position: bar on floor, clean grip, hip hinge."""
+        """Set starting position: bar on floor, clean grip, hip hinge.
+
+        Multi-DOF joints default to neutral for adduction/rotation.
+        """
         for side in ("l", "r"):
             set_coordinate_default(jointset, f"hip_{side}_flex", _FLOOR_PULL_HIP_ANGLE)
+            set_coordinate_default(jointset, f"hip_{side}_adduct", 0.0)
+            set_coordinate_default(jointset, f"hip_{side}_rotate", 0.0)
             set_coordinate_default(
                 jointset, f"knee_{side}_flex", _FLOOR_PULL_KNEE_ANGLE
             )

--- a/src/opensim_models/exercises/constants.py
+++ b/src/opensim_models/exercises/constants.py
@@ -12,6 +12,33 @@ _FLOOR_PULL_HIP_ANGLE: float = 1.3963  # ~80° hip flexion
 _FLOOR_PULL_KNEE_ANGLE: float = -1.0472  # ~60° knee flexion (negative convention)
 _FLOOR_PULL_LUMBAR_ANGLE: float = 0.5236  # ~30° lumbar flexion
 
+# Multi-DOF joint defaults for floor-pull exercises.
+_FLOOR_PULL_HIP_ADDUCT: float = 0.0  # neutral adduction
+_FLOOR_PULL_HIP_ROTATE: float = 0.0  # neutral rotation
+
+# Shoulder multi-DOF defaults.
+_SHOULDER_NEUTRAL_ADDUCT: float = 0.0  # neutral adduction
+_SHOULDER_NEUTRAL_ROTATE: float = 0.0  # neutral rotation
+
+# Lumbar multi-DOF defaults.
+_LUMBAR_NEUTRAL_LATERAL: float = 0.0  # neutral lateral flexion
+_LUMBAR_NEUTRAL_ROTATE: float = 0.0  # neutral rotation
+
+# Ankle multi-DOF defaults.
+_ANKLE_NEUTRAL_INVERSION: float = 0.0  # neutral inversion/eversion
+
+# Wrist multi-DOF defaults.
+_WRIST_NEUTRAL_DEVIATION: float = 0.0  # neutral radial/ulnar deviation
+
+# Squat-specific multi-DOF angles.
+_SQUAT_HIP_EXTERNAL_ROTATE: float = 0.1745  # ~10° external rotation
+
+# Bench press-specific multi-DOF angles.
+_BENCH_SHOULDER_ADDUCT: float = -0.5236  # ~-30° (abducted from midline)
+
+# Snatch-specific multi-DOF angles.
+_SNATCH_SHOULDER_ABDUCT: float = -0.3491  # ~-20° abduction for wide grip
+
 # Grip offsets from shaft centre (metres) for each exercise.
 _SNATCH_GRIP_HALF_WIDTH: float = 0.58  # Wide snatch grip (~1.5× shoulder width)
 _CLEAN_GRIP_HALF_WIDTH: float = 0.25  # Shoulder-width clean grip

--- a/src/opensim_models/exercises/deadlift/deadlift_model.py
+++ b/src/opensim_models/exercises/deadlift/deadlift_model.py
@@ -114,6 +114,7 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
 
         The bar is on the floor at PLATE_RADIUS height, so the body
         must flex at the hips (~80 deg) and knees (~60 deg) to reach.
+        Multi-DOF joints default to neutral (0) for adduction/rotation.
         Runs a feasibility check and emits a warning if hands are far
         from bar height.
         """
@@ -121,6 +122,8 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
             set_coordinate_default(
                 jointset, f"hip_{side}_flex", DEADLIFT_INITIAL_HIP_ANGLE
             )
+            set_coordinate_default(jointset, f"hip_{side}_adduct", 0.0)
+            set_coordinate_default(jointset, f"hip_{side}_rotate", 0.0)
             set_coordinate_default(
                 jointset, f"knee_{side}_flex", DEADLIFT_INITIAL_KNEE_ANGLE
             )

--- a/src/opensim_models/exercises/snatch/snatch_model.py
+++ b/src/opensim_models/exercises/snatch/snatch_model.py
@@ -78,12 +78,20 @@ class SnatchModelBuilder(ExerciseModelBuilder):
         )
 
     def set_initial_pose(self, jointset: ET.Element) -> None:
-        """Set starting position: bar on floor, wide grip, deep hip hinge."""
+        """Set starting position: bar on floor, wide grip, deep hip hinge.
+
+        Wide snatch grip requires slight shoulder abduction.
+        """
+        shoulder_abduct = -0.3491  # ~-20° abduction for wide grip
         for side in ("l", "r"):
             set_coordinate_default(jointset, f"hip_{side}_flex", _FLOOR_PULL_HIP_ANGLE)
+            set_coordinate_default(jointset, f"hip_{side}_adduct", 0.0)
+            set_coordinate_default(jointset, f"hip_{side}_rotate", 0.0)
             set_coordinate_default(
                 jointset, f"knee_{side}_flex", _FLOOR_PULL_KNEE_ANGLE
             )
+            set_coordinate_default(jointset, f"shoulder_{side}_adduct", shoulder_abduct)
+            set_coordinate_default(jointset, f"shoulder_{side}_rotate", 0.0)
         set_coordinate_default(jointset, "lumbar_flex", _FLOOR_PULL_LUMBAR_ANGLE)
 
 

--- a/src/opensim_models/exercises/squat/squat_model.py
+++ b/src/opensim_models/exercises/squat/squat_model.py
@@ -63,13 +63,20 @@ class SquatModelBuilder(ExerciseModelBuilder):
         )
 
     def set_initial_pose(self, jointset: ET.Element) -> None:
-        """Set standing unrack position: slight hip/knee flexion (~5 deg)."""
-        # Slight hip flexion (positive) and knee flexion (negative in this model)
+        """Set standing unrack position: slight hip/knee flexion (~5 deg).
+
+        Multi-DOF defaults: slight hip external rotation for squat stance.
+        """
         hip_flex = 0.0873  # ~5 degrees
         knee_flex = -0.0873  # ~5 degrees
+        hip_rotate = 0.1745  # ~10° external rotation for squat stance
         for side in ("l", "r"):
             set_coordinate_default(jointset, f"hip_{side}_flex", hip_flex)
+            set_coordinate_default(jointset, f"hip_{side}_adduct", 0.0)
+            set_coordinate_default(jointset, f"hip_{side}_rotate", hip_rotate)
             set_coordinate_default(jointset, f"knee_{side}_flex", knee_flex)
+            set_coordinate_default(jointset, f"ankle_{side}_flex", 0.0)
+            set_coordinate_default(jointset, f"ankle_{side}_inversion", 0.0)
 
 
 def build_squat_model(

--- a/src/opensim_models/shared/body/body_model.py
+++ b/src/opensim_models/shared/body/body_model.py
@@ -7,14 +7,14 @@ Segments (bilateral where noted):
 
 Joints:
   ground_pelvis (FreeJoint — 6 DOF),
-  lumbar (PinJoint — flexion/extension),
+  lumbar (BallJoint — 3 DOF: flex, lateral, rotation),
   neck (PinJoint),
-  shoulder_{l,r} (PinJoint — simplified, flexion only for v0.1),
+  shoulder_{l,r} (BallJoint — 3 DOF: flex, adduction, rotation),
   elbow_{l,r} (PinJoint),
-  wrist_{l,r} (PinJoint),
-  hip_{l,r} (PinJoint — flexion/extension),
+  wrist_{l,r} (CustomJoint — 2 DOF: flex, deviation),
+  hip_{l,r} (BallJoint — 3 DOF: flex, adduction, rotation),
   knee_{l,r} (PinJoint),
-  ankle_{l,r} (PinJoint)
+  ankle_{l,r} (CustomJoint — 2 DOF: flex, inversion)
 
 Anthropometric defaults are for a 50th-percentile male (height=1.75 m,
 mass=80 kg) following Winter (2009) segment proportions.
@@ -38,7 +38,9 @@ from opensim_models.shared.utils.geometry import (
     rectangular_prism_inertia,
 )
 from opensim_models.shared.utils.xml_helpers import (
+    add_ball_joint,
     add_body,
+    add_custom_joint,
     add_free_joint,
     add_pin_joint,
 )
@@ -148,6 +150,110 @@ def _add_bilateral_limb(
         )
 
 
+def _add_bilateral_ball_joint_limb(
+    bodyset: ET.Element,
+    jointset: ET.Element,
+    spec: BodyModelSpec,
+    *,
+    seg_name: str,
+    parent_name: str,
+    parent_offset_y: float,
+    parent_lateral_x: float,
+    coord_prefix: str,
+    coord_suffixes: tuple[str, str, str],
+    ranges: tuple[
+        tuple[float, float],
+        tuple[float, float],
+        tuple[float, float],
+    ],
+) -> None:
+    """Add left and right limb segments with BallJoints (3-DOF)."""
+    mass, length, radius = _seg(spec, seg_name)
+    inertia = cylinder_inertia(mass, radius, length)
+
+    for side, sign in [("l", -1.0), ("r", 1.0)]:
+        body_name = f"{seg_name}_{side}"
+        add_body(
+            bodyset,
+            name=body_name,
+            mass=mass,
+            mass_center=(0, -length / 2.0, 0),
+            inertia_xx=inertia[0],
+            inertia_yy=inertia[1],
+            inertia_zz=inertia[2],
+        )
+        coordinates = [
+            {
+                "name": f"{coord_prefix}_{side}_{suffix}",
+                "default_value": 0.0,
+                "range_min": rng[0],
+                "range_max": rng[1],
+            }
+            for suffix, rng in zip(coord_suffixes, ranges, strict=True)
+        ]
+        add_ball_joint(
+            jointset,
+            name=f"{coord_prefix}_{side}",
+            parent_body=f"{parent_name}_{side}"
+            if parent_name in _BILATERAL_SEGMENTS
+            else parent_name,
+            child_body=body_name,
+            location_in_parent=(sign * parent_lateral_x, parent_offset_y, 0),
+            location_in_child=(0, 0, 0),
+            coordinates=coordinates,
+        )
+
+
+def _add_bilateral_custom_joint_limb(
+    bodyset: ET.Element,
+    jointset: ET.Element,
+    spec: BodyModelSpec,
+    *,
+    seg_name: str,
+    parent_name: str,
+    parent_offset_y: float,
+    parent_lateral_x: float,
+    coord_prefix: str,
+    coord_defs: list[dict[str, str | float]],
+) -> None:
+    """Add left and right limb segments with CustomJoints (N-DOF)."""
+    mass, length, radius = _seg(spec, seg_name)
+    inertia = cylinder_inertia(mass, radius, length)
+
+    for side, sign in [("l", -1.0), ("r", 1.0)]:
+        body_name = f"{seg_name}_{side}"
+        add_body(
+            bodyset,
+            name=body_name,
+            mass=mass,
+            mass_center=(0, -length / 2.0, 0),
+            inertia_xx=inertia[0],
+            inertia_yy=inertia[1],
+            inertia_zz=inertia[2],
+        )
+        coordinates = [
+            {
+                "name": f"{coord_prefix}_{side}_{c['suffix']}",
+                "default_value": float(c.get("default_value", 0.0)),
+                "range_min": float(c["range_min"]),
+                "range_max": float(c["range_max"]),
+                "axis": str(c.get("axis", "0 0 1")),
+            }
+            for c in coord_defs
+        ]
+        add_custom_joint(
+            jointset,
+            name=f"{coord_prefix}_{side}",
+            parent_body=f"{parent_name}_{side}"
+            if parent_name in _BILATERAL_SEGMENTS
+            else parent_name,
+            child_body=body_name,
+            location_in_parent=(sign * parent_lateral_x, parent_offset_y, 0),
+            location_in_child=(0, 0, 0),
+            coordinates=coordinates,
+        )
+
+
 def create_full_body(
     bodyset: ET.Element,
     jointset: ET.Element,
@@ -218,16 +324,33 @@ def create_full_body(
         inertia_yy=t_inertia[1],
         inertia_zz=t_inertia[2],
     )
-    add_pin_joint(
+    add_ball_joint(
         jointset,
         name="lumbar",
         parent_body="pelvis",
         child_body="torso",
         location_in_parent=(0, p_len / 2.0, 0),
         location_in_child=(0, 0, 0),
-        coord_name="lumbar_flex",
-        range_min=-0.5236,
-        range_max=1.0472,  # ~60° — lower end of clinical range (60–80°)
+        coordinates=[
+            {
+                "name": "lumbar_flex",
+                "default_value": 0.0,
+                "range_min": -0.5236,  # -30°
+                "range_max": 0.7854,  # 45°
+            },
+            {
+                "name": "lumbar_lateral",
+                "default_value": 0.0,
+                "range_min": -0.5236,  # -30°
+                "range_max": 0.5236,  # 30°
+            },
+            {
+                "name": "lumbar_rotate",
+                "default_value": 0.0,
+                "range_min": -0.5236,  # -30°
+                "range_max": 0.5236,  # 30°
+            },
+        ],
     )
 
     # --- Head ---
@@ -258,7 +381,7 @@ def create_full_body(
     shoulder_y = t_len * 0.95
     shoulder_x = t_rad * 1.2
 
-    _add_bilateral_limb(
+    _add_bilateral_ball_joint_limb(
         bodyset,
         jointset,
         spec,
@@ -267,8 +390,12 @@ def create_full_body(
         parent_offset_y=shoulder_y,
         parent_lateral_x=shoulder_x,
         coord_prefix="shoulder",
-        range_min=-3.1416,
-        range_max=3.1416,
+        coord_suffixes=("flex", "adduct", "rotate"),
+        ranges=(
+            (-1.0472, 3.1416),  # flexion: -60° to 180°
+            (-0.5236, 3.1416),  # abduction: -30° to 180°
+            (-1.5708, 1.5708),  # rotation: -90° to 90°
+        ),
     )
 
     _, ua_len, _ = _seg(spec, "upper_arm")
@@ -286,7 +413,7 @@ def create_full_body(
     )
 
     _, fa_len, _ = _seg(spec, "forearm")
-    _add_bilateral_limb(
+    _add_bilateral_custom_joint_limb(
         bodyset,
         jointset,
         spec,
@@ -295,14 +422,26 @@ def create_full_body(
         parent_offset_y=-fa_len,
         parent_lateral_x=0,
         coord_prefix="wrist",
-        range_min=-1.2217,
-        range_max=1.2217,
+        coord_defs=[
+            {
+                "suffix": "flex",
+                "range_min": -1.2217,  # -70°
+                "range_max": 1.2217,  # 70°
+                "axis": "0 0 1",
+            },
+            {
+                "suffix": "deviation",
+                "range_min": -0.3491,  # -20°
+                "range_max": 0.5236,  # 30°
+                "axis": "1 0 0",
+            },
+        ],
     )
 
     # --- Legs ---
     hip_x = p_rad * 0.6
 
-    _add_bilateral_limb(
+    _add_bilateral_ball_joint_limb(
         bodyset,
         jointset,
         spec,
@@ -311,8 +450,12 @@ def create_full_body(
         parent_offset_y=-p_len / 2.0,
         parent_lateral_x=hip_x,
         coord_prefix="hip",
-        range_min=-0.5236,
-        range_max=2.0944,
+        coord_suffixes=("flex", "adduct", "rotate"),
+        ranges=(
+            (-0.5236, 2.0944),  # flexion: -30° to 120°
+            (-0.7854, 0.5236),  # abduction/adduction: -45° to 30°
+            (-0.7854, 0.7854),  # rotation: -45° to 45°
+        ),
     )
 
     _, th_len, _ = _seg(spec, "thigh")
@@ -330,7 +473,7 @@ def create_full_body(
     )
 
     _, sh_len, _ = _seg(spec, "shank")
-    _add_bilateral_limb(
+    _add_bilateral_custom_joint_limb(
         bodyset,
         jointset,
         spec,
@@ -339,8 +482,20 @@ def create_full_body(
         parent_offset_y=-sh_len,
         parent_lateral_x=0,
         coord_prefix="ankle",
-        range_min=-0.8727,  # ~-50° plantarflexion (physiological max)
-        range_max=0.3491,  # ~+20° dorsiflexion (physiological max)
+        coord_defs=[
+            {
+                "suffix": "flex",
+                "range_min": -0.3491,  # -20° dorsiflexion
+                "range_max": 0.8727,  # 50° plantarflexion
+                "axis": "0 0 1",
+            },
+            {
+                "suffix": "inversion",
+                "range_min": -0.3491,  # -20° eversion
+                "range_max": 0.3491,  # 20° inversion
+                "axis": "1 0 0",
+            },
+        ],
     )
 
     logger.info("Full-body model complete: %d bodies created", len(bodies))

--- a/src/opensim_models/shared/utils/xml_helpers.py
+++ b/src/opensim_models/shared/utils/xml_helpers.py
@@ -85,6 +85,124 @@ def add_pin_joint(
     return joint
 
 
+def add_ball_joint(
+    jointset: ET.Element,
+    *,
+    name: str,
+    parent_body: str,
+    child_body: str,
+    location_in_parent: tuple[float, float, float],
+    location_in_child: tuple[float, float, float],
+    orientation_in_parent: tuple[float, float, float] = (0, 0, 0),
+    orientation_in_child: tuple[float, float, float] = (0, 0, 0),
+    coordinates: list[dict[str, float | str]],
+) -> ET.Element:
+    """Append a <BallJoint> (3-DOF rotation) to *jointset* and return it.
+
+    *coordinates* is a list of 3 dicts, each with keys:
+      - ``name`` (str): coordinate name
+      - ``default_value`` (float): initial value in radians
+      - ``range_min`` (float): lower bound in radians
+      - ``range_max`` (float): upper bound in radians
+    """
+    if len(coordinates) != 3:
+        raise ValueError(
+            f"BallJoint requires exactly 3 coordinates, got {len(coordinates)}"
+        )
+
+    joint = ET.SubElement(jointset, "BallJoint", name=name)
+
+    # Parent frame
+    pf = ET.SubElement(joint, "PhysicalOffsetFrame", name=f"{name}_parent")
+    ET.SubElement(pf, "socket_parent").text = f"/bodyset/{parent_body}"
+    ET.SubElement(pf, "translation").text = vec3_str(*location_in_parent)
+    ET.SubElement(pf, "orientation").text = vec3_str(*orientation_in_parent)
+
+    # Child frame
+    cf = ET.SubElement(joint, "PhysicalOffsetFrame", name=f"{name}_child")
+    ET.SubElement(cf, "socket_parent").text = f"/bodyset/{child_body}"
+    ET.SubElement(cf, "translation").text = vec3_str(*location_in_child)
+    ET.SubElement(cf, "orientation").text = vec3_str(*orientation_in_child)
+
+    ET.SubElement(joint, "socket_parent_frame").text = f"{name}_parent"
+    ET.SubElement(joint, "socket_child_frame").text = f"{name}_child"
+
+    # CoordinateSet
+    coord_set = ET.SubElement(joint, "coordinates")
+    for c in coordinates:
+        coord = ET.SubElement(coord_set, "Coordinate", name=str(c["name"]))
+        ET.SubElement(coord, "default_value").text = f"{float(c['default_value']):.6f}"
+        ET.SubElement(
+            coord, "range"
+        ).text = f"{float(c['range_min']):.6f} {float(c['range_max']):.6f}"
+
+    return joint
+
+
+def add_custom_joint(
+    jointset: ET.Element,
+    *,
+    name: str,
+    parent_body: str,
+    child_body: str,
+    location_in_parent: tuple[float, float, float],
+    location_in_child: tuple[float, float, float],
+    orientation_in_parent: tuple[float, float, float] = (0, 0, 0),
+    orientation_in_child: tuple[float, float, float] = (0, 0, 0),
+    coordinates: list[dict[str, float | str]],
+) -> ET.Element:
+    """Append a <CustomJoint> (N-DOF) to *jointset* and return it.
+
+    *coordinates* is a list of dicts (1 or more), each with keys:
+      - ``name`` (str): coordinate name
+      - ``default_value`` (float): initial value in radians
+      - ``range_min`` (float): lower bound in radians
+      - ``range_max`` (float): upper bound in radians
+      - ``axis`` (str, optional): rotation axis, e.g. "1 0 0" (defaults to "0 0 1")
+    """
+    if len(coordinates) < 1:
+        raise ValueError("CustomJoint requires at least 1 coordinate")
+
+    joint = ET.SubElement(jointset, "CustomJoint", name=name)
+
+    # Parent frame
+    pf = ET.SubElement(joint, "PhysicalOffsetFrame", name=f"{name}_parent")
+    ET.SubElement(pf, "socket_parent").text = f"/bodyset/{parent_body}"
+    ET.SubElement(pf, "translation").text = vec3_str(*location_in_parent)
+    ET.SubElement(pf, "orientation").text = vec3_str(*orientation_in_parent)
+
+    # Child frame
+    cf = ET.SubElement(joint, "PhysicalOffsetFrame", name=f"{name}_child")
+    ET.SubElement(cf, "socket_parent").text = f"/bodyset/{child_body}"
+    ET.SubElement(cf, "translation").text = vec3_str(*location_in_child)
+    ET.SubElement(cf, "orientation").text = vec3_str(*orientation_in_child)
+
+    ET.SubElement(joint, "socket_parent_frame").text = f"{name}_parent"
+    ET.SubElement(joint, "socket_child_frame").text = f"{name}_child"
+
+    # Coordinates
+    coord_set = ET.SubElement(joint, "coordinates")
+    for c in coordinates:
+        coord = ET.SubElement(coord_set, "Coordinate", name=str(c["name"]))
+        ET.SubElement(coord, "default_value").text = f"{float(c['default_value']):.6f}"
+        ET.SubElement(
+            coord, "range"
+        ).text = f"{float(c['range_min']):.6f} {float(c['range_max']):.6f}"
+
+    # SpatialTransform with TransformAxis elements
+    spatial = ET.SubElement(joint, "SpatialTransform")
+    rotation_axes = ["rotation1", "rotation2", "rotation3"]
+    translation_axes = ["translation1", "translation2", "translation3"]
+
+    for i, c in enumerate(coordinates):
+        axis_name = rotation_axes[i] if i < 3 else translation_axes[i - 3]
+        ta = ET.SubElement(spatial, "TransformAxis", name=axis_name)
+        ET.SubElement(ta, "coordinates").text = str(c["name"])
+        ET.SubElement(ta, "axis").text = str(c.get("axis", "0 0 1"))
+
+    return joint
+
+
 def add_free_joint(
     jointset: ET.Element,
     *,

--- a/tests/unit/shared/test_body_model.py
+++ b/tests/unit/shared/test_body_model.py
@@ -73,6 +73,61 @@ class TestCreateFullBody:
         names = [j.get("name") for j in free_joints]  # type: ignore
         assert "ground_pelvis" in names
 
+    def test_hip_is_ball_joint(self, model_elements):
+        _, jointset, _ = model_elements
+        ball_joints = jointset.findall("BallJoint")
+        names = [j.get("name") for j in ball_joints]  # type: ignore
+        assert "hip_l" in names
+        assert "hip_r" in names
+
+    def test_shoulder_is_ball_joint(self, model_elements):
+        _, jointset, _ = model_elements
+        ball_joints = jointset.findall("BallJoint")
+        names = [j.get("name") for j in ball_joints]  # type: ignore
+        assert "shoulder_l" in names
+        assert "shoulder_r" in names
+
+    def test_lumbar_is_ball_joint(self, model_elements):
+        _, jointset, _ = model_elements
+        ball_joints = jointset.findall("BallJoint")
+        names = [j.get("name") for j in ball_joints]  # type: ignore
+        assert "lumbar" in names
+
+    def test_ankle_is_custom_joint(self, model_elements):
+        _, jointset, _ = model_elements
+        custom_joints = jointset.findall("CustomJoint")
+        names = [j.get("name") for j in custom_joints]  # type: ignore
+        assert "ankle_l" in names
+        assert "ankle_r" in names
+
+    def test_wrist_is_custom_joint(self, model_elements):
+        _, jointset, _ = model_elements
+        custom_joints = jointset.findall("CustomJoint")
+        names = [j.get("name") for j in custom_joints]  # type: ignore
+        assert "wrist_l" in names
+        assert "wrist_r" in names
+
+    def test_hip_has_three_coordinates(self, model_elements):
+        _, jointset, _ = model_elements
+        for ball in jointset.findall("BallJoint"):
+            if ball.get("name") == "hip_r":
+                coords = ball.findall(".//Coordinate")
+                assert len(coords) == 3
+                coord_names = {c.get("name") for c in coords}
+                assert "hip_r_flex" in coord_names
+                assert "hip_r_adduct" in coord_names
+                assert "hip_r_rotate" in coord_names
+
+    def test_ankle_has_two_coordinates(self, model_elements):
+        _, jointset, _ = model_elements
+        for cj in jointset.findall("CustomJoint"):
+            if cj.get("name") == "ankle_r":
+                coords = cj.findall(".//Coordinate")
+                assert len(coords) == 2
+                coord_names = {c.get("name") for c in coords}
+                assert "ankle_r_flex" in coord_names
+                assert "ankle_r_inversion" in coord_names
+
     def test_all_masses_positive(self, model_elements):
         bodyset, _, _ = model_elements
         for body in bodyset.findall("Body"):

--- a/tests/unit/shared/test_xml_helpers.py
+++ b/tests/unit/shared/test_xml_helpers.py
@@ -2,8 +2,12 @@
 
 import xml.etree.ElementTree as ET
 
+import pytest
+
 from opensim_models.shared.utils.xml_helpers import (
+    add_ball_joint,
     add_body,
+    add_custom_joint,
     add_free_joint,
     add_pin_joint,
     add_weld_joint,
@@ -114,6 +118,142 @@ class TestAddWeldJoint:
             location_in_parent=(0, 1, 0),
         )
         assert joint.tag == "WeldJoint"
+
+
+class TestAddBallJoint:
+    def test_creates_ball_joint(self):
+        jointset = ET.Element("JointSet")
+        coords = [
+            {"name": "flex", "default_value": 0.0, "range_min": -1.0, "range_max": 1.0},
+            {
+                "name": "adduct",
+                "default_value": 0.0,
+                "range_min": -0.5,
+                "range_max": 0.5,
+            },
+            {
+                "name": "rotate",
+                "default_value": 0.0,
+                "range_min": -0.7,
+                "range_max": 0.7,
+            },
+        ]
+        joint = add_ball_joint(
+            jointset,
+            name="hip_r",
+            parent_body="pelvis",
+            child_body="thigh_r",
+            location_in_parent=(0, 0, 0),
+            location_in_child=(0, 0, 0),
+            coordinates=coords,
+        )
+        assert joint.tag == "BallJoint"
+        assert joint.get("name") == "hip_r"
+
+    def test_has_three_coordinates(self):
+        jointset = ET.Element("JointSet")
+        coords = [
+            {"name": "c1", "default_value": 0.0, "range_min": -1.0, "range_max": 1.0},
+            {"name": "c2", "default_value": 0.0, "range_min": -1.0, "range_max": 1.0},
+            {"name": "c3", "default_value": 0.0, "range_min": -1.0, "range_max": 1.0},
+        ]
+        joint = add_ball_joint(
+            jointset,
+            name="test",
+            parent_body="p",
+            child_body="c",
+            location_in_parent=(0, 0, 0),
+            location_in_child=(0, 0, 0),
+            coordinates=coords,
+        )
+        all_coords = joint.findall(".//Coordinate")
+        assert len(all_coords) == 3
+
+    def test_rejects_wrong_coordinate_count(self):
+        jointset = ET.Element("JointSet")
+        coords = [
+            {"name": "c1", "default_value": 0.0, "range_min": -1.0, "range_max": 1.0},
+        ]
+        with pytest.raises(ValueError, match="exactly 3 coordinates"):
+            add_ball_joint(
+                jointset,
+                name="bad",
+                parent_body="p",
+                child_body="c",
+                location_in_parent=(0, 0, 0),
+                location_in_child=(0, 0, 0),
+                coordinates=coords,
+            )
+
+    def test_has_parent_and_child_frames(self):
+        jointset = ET.Element("JointSet")
+        coords = [
+            {"name": "c1", "default_value": 0.0, "range_min": -1.0, "range_max": 1.0},
+            {"name": "c2", "default_value": 0.0, "range_min": -1.0, "range_max": 1.0},
+            {"name": "c3", "default_value": 0.0, "range_min": -1.0, "range_max": 1.0},
+        ]
+        joint = add_ball_joint(
+            jointset,
+            name="j",
+            parent_body="p",
+            child_body="c",
+            location_in_parent=(0, 1, 0),
+            location_in_child=(0, 0, 0),
+            coordinates=coords,
+        )
+        parent_frame = joint.find("PhysicalOffsetFrame[@name='j_parent']")
+        child_frame = joint.find("PhysicalOffsetFrame[@name='j_child']")
+        assert parent_frame is not None
+        assert child_frame is not None
+
+
+class TestAddCustomJoint:
+    def test_creates_custom_joint(self):
+        jointset = ET.Element("JointSet")
+        coords = [
+            {"name": "flex", "default_value": 0.0, "range_min": -1.0, "range_max": 1.0},
+            {"name": "dev", "default_value": 0.0, "range_min": -0.5, "range_max": 0.5},
+        ]
+        joint = add_custom_joint(
+            jointset,
+            name="wrist_r",
+            parent_body="forearm_r",
+            child_body="hand_r",
+            location_in_parent=(0, 0, 0),
+            location_in_child=(0, 0, 0),
+            coordinates=coords,
+        )
+        assert joint.tag == "CustomJoint"
+
+    def test_has_spatial_transform(self):
+        jointset = ET.Element("JointSet")
+        coords = [
+            {"name": "flex", "default_value": 0.0, "range_min": -1.0, "range_max": 1.0},
+        ]
+        joint = add_custom_joint(
+            jointset,
+            name="test",
+            parent_body="p",
+            child_body="c",
+            location_in_parent=(0, 0, 0),
+            location_in_child=(0, 0, 0),
+            coordinates=coords,
+        )
+        spatial = joint.find("SpatialTransform")
+        assert spatial is not None
+
+    def test_rejects_empty_coordinates(self):
+        jointset = ET.Element("JointSet")
+        with pytest.raises(ValueError, match="at least 1 coordinate"):
+            add_custom_joint(
+                jointset,
+                name="bad",
+                parent_body="p",
+                child_body="c",
+                location_in_parent=(0, 0, 0),
+                location_in_child=(0, 0, 0),
+                coordinates=[],
+            )
 
 
 class TestSerializeModel:


### PR DESCRIPTION
## Summary
- **Add `add_ball_joint` (3-DOF) and `add_custom_joint` (N-DOF) helpers** to `xml_helpers.py`, following the same pattern as existing `add_pin_joint` / `add_free_joint`
- **Upgrade 5 joint groups** from single-DOF PinJoints to anatomically accurate multi-DOF joints:
  - Hip: BallJoint (flexion/extension, abduction/adduction, internal/external rotation)
  - Shoulder: BallJoint (flexion, abduction, rotation)
  - Lumbar: BallJoint (flexion, lateral flexion, rotation)
  - Ankle: CustomJoint (dorsiflexion/plantarflexion, inversion/eversion)
  - Wrist: CustomJoint (flexion/extension, radial/ulnar deviation)
- **Update all 5 exercise builders** (`set_initial_pose`) to set defaults for new coordinates (squat adds hip external rotation, bench adds shoulder adduction, snatch adds shoulder abduction)
- **Add multi-DOF angle constants** to `exercises/constants.py`
- **Add 14 new tests** covering BallJoint/CustomJoint creation, coordinate counts, joint type verification, and validation error cases

## Test plan
- [x] All 229 tests pass (`python -m pytest tests/ -x --tb=short`)
- [x] `ruff check` passes with zero violations
- [x] `ruff format` produces no diffs
- [ ] Verify generated XML renders correctly in OpenSim GUI (manual)
- [ ] Confirm coordinate ranges match clinical ROM data

🤖 Generated with [Claude Code](https://claude.com/claude-code)