### PR TITLE
feat: add ground contact models

### DIFF
--- a/src/opensim_models/exercises/base.py
+++ b/src/opensim_models/exercises/base.py
@@ -18,8 +18,13 @@ from dataclasses import dataclass, field
 
 from opensim_models.shared.barbell import BarbellSpec, create_barbell_bodies
 from opensim_models.shared.body import BodyModelSpec, create_full_body
+from opensim_models.shared.body.body_model import _add_foot_contact_spheres
 from opensim_models.shared.contracts.postconditions import ensure_valid_xml
-from opensim_models.shared.utils.xml_helpers import serialize_model
+from opensim_models.shared.utils.xml_helpers import (
+    add_contact_half_space,
+    add_hunt_crossley_force,
+    serialize_model,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -75,12 +80,20 @@ class ExerciseModelBuilder(ABC):
         """
 
     def _skip_ground_joint(self) -> bool:
-        """Return True if the pelvis–ground FreeJoint should be omitted.
+        """Return True if the pelvis-ground FreeJoint should be omitted.
 
         Override in subclasses that supply their own pelvis parent joint
         (e.g. bench press, where pelvis is welded to the bench body).
         """
         return False
+
+    def _post_contact_hook(self, model: ET.Element) -> None:  # noqa: B027
+        """Hook called after standard ground contact is added.
+
+        Subclasses may override to inject additional contact surfaces
+        (e.g. a bench contact surface for bench press).
+        The default implementation is a no-op.
+        """
 
     def build(self) -> str:
         """Build the complete OpenSim model XML and return as string.
@@ -126,6 +139,27 @@ class ExerciseModelBuilder(ABC):
 
         # Exercise-specific initial pose
         self.set_initial_pose(jointset)
+
+        # --- Ground contact geometry and forces ---
+        add_contact_half_space(model, name="ground_contact", body="ground")
+        _add_foot_contact_spheres(model, self.config.body_spec)
+
+        # Connect each foot contact sphere to the ground half-space
+        foot_contact_names = [
+            f"foot_{side}_{point}"
+            for side in ("l", "r")
+            for point in ("heel_medial", "heel_lateral", "toe_medial", "toe_lateral")
+        ]
+        for sphere_name in foot_contact_names:
+            add_hunt_crossley_force(
+                model,
+                name=f"force_{sphere_name}",
+                contact_geometry_1=sphere_name,
+                contact_geometry_2="ground_contact",
+            )
+
+        # Subclass hook for additional contact surfaces
+        self._post_contact_hook(model)
 
         xml_str = serialize_model(root)
 

--- a/src/opensim_models/exercises/bench_press/bench_press_model.py
+++ b/src/opensim_models/exercises/bench_press/bench_press_model.py
@@ -24,6 +24,9 @@ from opensim_models.exercises.base import ExerciseConfig, ExerciseModelBuilder
 from opensim_models.shared.utils.geometry import rectangular_prism_inertia
 from opensim_models.shared.utils.xml_helpers import (
     add_body,
+    add_contact_half_space,
+    add_contact_sphere,
+    add_hunt_crossley_force,
     add_weld_joint,
     set_coordinate_default,
 )
@@ -156,6 +159,29 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
     def _pre_attach_hook(self, bodyset: ET.Element, jointset: ET.Element) -> None:
         """Inject the bench body and pelvis-to-bench constraint."""
         self._add_bench_and_constraint(bodyset, jointset)
+
+    def _post_contact_hook(self, model: ET.Element) -> None:
+        """Add bench contact surface and pelvis-to-bench contact force."""
+        add_contact_half_space(
+            model,
+            name="bench_contact",
+            body="bench",
+            location=(0, _BENCH_HEIGHT_DIM / 2.0, 0),
+            orientation=(0, 0, -math.pi / 2),
+        )
+        add_contact_sphere(
+            model,
+            name="pelvis_contact",
+            body="pelvis",
+            location=(0, -0.05, 0),
+            radius=0.05,
+        )
+        add_hunt_crossley_force(
+            model,
+            name="force_pelvis_bench",
+            contact_geometry_1="pelvis_contact",
+            contact_geometry_2="bench_contact",
+        )
 
     def set_initial_pose(self, jointset: ET.Element) -> None:
         """Set supine lockout position.

--- a/src/opensim_models/shared/body/body_model.py
+++ b/src/opensim_models/shared/body/body_model.py
@@ -40,6 +40,7 @@ from opensim_models.shared.utils.geometry import (
 from opensim_models.shared.utils.xml_helpers import (
     add_ball_joint,
     add_body,
+    add_contact_sphere,
     add_custom_joint,
     add_free_joint,
     add_pin_joint,
@@ -252,6 +253,38 @@ def _add_bilateral_custom_joint_limb(
             location_in_child=(0, 0, 0),
             coordinates=coordinates,
         )
+
+
+def _add_foot_contact_spheres(
+    model: ET.Element,
+    spec: BodyModelSpec,
+) -> None:
+    """Add 4 contact spheres per foot (8 total) for ground contact.
+
+    Contact points per foot:
+      - heel_medial, heel_lateral, toe_medial, toe_lateral
+    Positions are relative to the foot body's center, with sole_thickness
+    derived from the foot segment radius.
+    """
+    _, _, foot_radius = _seg(spec, "foot")
+    sole_thickness = foot_radius
+
+    contact_points = {
+        "heel_medial": (-0.08, -0.03, -sole_thickness),
+        "heel_lateral": (-0.08, 0.03, -sole_thickness),
+        "toe_medial": (0.12, -0.03, -sole_thickness),
+        "toe_lateral": (0.12, 0.03, -sole_thickness),
+    }
+
+    for side in ("l", "r"):
+        for point_name, location in contact_points.items():
+            add_contact_sphere(
+                model,
+                name=f"foot_{side}_{point_name}",
+                body=f"foot_{side}",
+                location=location,
+                radius=0.02,
+            )
 
 
 def create_full_body(

--- a/src/opensim_models/shared/utils/xml_helpers.py
+++ b/src/opensim_models/shared/utils/xml_helpers.py
@@ -259,6 +259,77 @@ def add_weld_joint(
     return joint
 
 
+def add_contact_half_space(
+    model: ET.Element,
+    *,
+    name: str = "ground_contact",
+    body: str = "ground",
+    location: tuple[float, float, float] = (0, 0, 0),
+    orientation: tuple[float, float, float] = (0, 0, -1.5708),
+) -> ET.Element:
+    """Add a ContactHalfSpace geometry to the model's ContactGeometrySet.
+
+    The default orientation (-90 deg about Z) makes the half-space surface
+    point in the +Y direction, which is the standard ground normal in OpenSim.
+    """
+    cg_set = model.find("ContactGeometrySet")
+    if cg_set is None:
+        cg_set = ET.SubElement(model, "ContactGeometrySet")
+    geom = ET.SubElement(cg_set, "ContactHalfSpace", name=name)
+    ET.SubElement(geom, "socket_frame").text = f"/bodyset/{body}" if body != "ground" else "/ground"
+    ET.SubElement(geom, "location").text = vec3_str(*location)
+    ET.SubElement(geom, "orientation").text = vec3_str(*orientation)
+    return geom
+
+
+def add_contact_sphere(
+    model: ET.Element,
+    *,
+    name: str,
+    body: str,
+    location: tuple[float, float, float],
+    radius: float = 0.02,
+) -> ET.Element:
+    """Add a ContactSphere geometry for foot contact points."""
+    if radius <= 0:
+        raise ValueError(f"Contact sphere radius must be positive, got {radius}")
+    cg_set = model.find("ContactGeometrySet")
+    if cg_set is None:
+        cg_set = ET.SubElement(model, "ContactGeometrySet")
+    geom = ET.SubElement(cg_set, "ContactSphere", name=name)
+    ET.SubElement(geom, "socket_frame").text = f"/bodyset/{body}"
+    ET.SubElement(geom, "location").text = vec3_str(*location)
+    ET.SubElement(geom, "radius").text = f"{radius:.6f}"
+    return geom
+
+
+def add_hunt_crossley_force(
+    model: ET.Element,
+    *,
+    name: str,
+    contact_geometry_1: str,
+    contact_geometry_2: str,
+    stiffness: float = 1e7,
+    dissipation: float = 0.5,
+    static_friction: float = 0.8,
+    dynamic_friction: float = 0.6,
+    viscous_friction: float = 0.2,
+) -> ET.Element:
+    """Add a HuntCrossleyForce between two contact geometries."""
+    force_set = model.find("ForceSet")
+    if force_set is None:
+        force_set = ET.SubElement(model, "ForceSet")
+    force = ET.SubElement(force_set, "HuntCrossleyForce", name=name)
+    ET.SubElement(force, "contact_geometry_1").text = contact_geometry_1
+    ET.SubElement(force, "contact_geometry_2").text = contact_geometry_2
+    ET.SubElement(force, "stiffness").text = f"{stiffness:.1f}"
+    ET.SubElement(force, "dissipation").text = f"{dissipation:.6f}"
+    ET.SubElement(force, "static_friction").text = f"{static_friction:.6f}"
+    ET.SubElement(force, "dynamic_friction").text = f"{dynamic_friction:.6f}"
+    ET.SubElement(force, "viscous_friction").text = f"{viscous_friction:.6f}"
+    return force
+
+
 def set_coordinate_default(jointset: ET.Element, coord_name: str, value: float) -> None:
     """Set the default_value for a named Coordinate in the JointSet.
 

--- a/tests/unit/shared/test_ground_contact.py
+++ b/tests/unit/shared/test_ground_contact.py
@@ -1,0 +1,206 @@
+"""Tests for ground contact geometry and force elements."""
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from opensim_models.exercises.bench_press.bench_press_model import (
+    BenchPressModelBuilder,
+)
+from opensim_models.exercises.squat.squat_model import SquatModelBuilder
+from opensim_models.shared.utils.xml_helpers import (
+    add_contact_half_space,
+    add_contact_sphere,
+    add_hunt_crossley_force,
+)
+
+
+class TestContactHalfSpace:
+    def test_creates_element(self):
+        model = ET.Element("Model")
+        geom = add_contact_half_space(model, name="ground_contact", body="ground")
+        assert geom.tag == "ContactHalfSpace"
+        assert geom.get("name") == "ground_contact"
+
+    def test_socket_frame_ground(self):
+        model = ET.Element("Model")
+        geom = add_contact_half_space(model, name="gc", body="ground")
+        assert geom.find("socket_frame").text == "/ground"
+
+    def test_socket_frame_non_ground(self):
+        model = ET.Element("Model")
+        geom = add_contact_half_space(model, name="bc", body="bench")
+        assert geom.find("socket_frame").text == "/bodyset/bench"
+
+    def test_creates_contact_geometry_set(self):
+        model = ET.Element("Model")
+        add_contact_half_space(model)
+        cg_set = model.find("ContactGeometrySet")
+        assert cg_set is not None
+        assert len(cg_set) == 1
+
+    def test_reuses_existing_contact_geometry_set(self):
+        model = ET.Element("Model")
+        add_contact_half_space(model, name="gc1")
+        add_contact_half_space(model, name="gc2", body="bench")
+        cg_sets = model.findall("ContactGeometrySet")
+        assert len(cg_sets) == 1
+        assert len(cg_sets[0]) == 2
+
+
+class TestContactSphere:
+    def test_creates_element(self):
+        model = ET.Element("Model")
+        geom = add_contact_sphere(
+            model, name="foot_l_heel", body="foot_l", location=(0, 0, 0)
+        )
+        assert geom.tag == "ContactSphere"
+        assert geom.get("name") == "foot_l_heel"
+
+    def test_has_radius(self):
+        model = ET.Element("Model")
+        geom = add_contact_sphere(
+            model, name="cs", body="foot_l", location=(0, 0, 0), radius=0.03
+        )
+        assert geom.find("radius").text == "0.030000"
+
+    def test_rejects_nonpositive_radius(self):
+        model = ET.Element("Model")
+        with pytest.raises(ValueError, match="positive"):
+            add_contact_sphere(
+                model, name="bad", body="foot_l", location=(0, 0, 0), radius=0.0
+            )
+
+    def test_has_location(self):
+        model = ET.Element("Model")
+        geom = add_contact_sphere(
+            model, name="cs", body="foot_l", location=(0.1, -0.02, -0.03)
+        )
+        loc_text = geom.find("location").text
+        assert "0.100000" in loc_text
+        assert "-0.020000" in loc_text
+
+
+class TestHuntCrossleyForce:
+    def test_creates_element(self):
+        model = ET.Element("Model")
+        force = add_hunt_crossley_force(
+            model,
+            name="force_foot",
+            contact_geometry_1="foot_sphere",
+            contact_geometry_2="ground_contact",
+        )
+        assert force.tag == "HuntCrossleyForce"
+        assert force.get("name") == "force_foot"
+
+    def test_has_contact_geometry_refs(self):
+        model = ET.Element("Model")
+        force = add_hunt_crossley_force(
+            model,
+            name="f",
+            contact_geometry_1="s1",
+            contact_geometry_2="s2",
+        )
+        assert force.find("contact_geometry_1").text == "s1"
+        assert force.find("contact_geometry_2").text == "s2"
+
+    def test_has_default_parameters(self):
+        model = ET.Element("Model")
+        force = add_hunt_crossley_force(
+            model,
+            name="f",
+            contact_geometry_1="s1",
+            contact_geometry_2="s2",
+        )
+        assert float(force.find("stiffness").text) == pytest.approx(1e7)
+        assert float(force.find("dissipation").text) == pytest.approx(0.5)
+        assert float(force.find("static_friction").text) == pytest.approx(0.8)
+
+    def test_creates_force_set(self):
+        model = ET.Element("Model")
+        add_hunt_crossley_force(
+            model, name="f", contact_geometry_1="a", contact_geometry_2="b"
+        )
+        fs = model.find("ForceSet")
+        assert fs is not None
+        assert len(fs) == 1
+
+    def test_reuses_existing_force_set(self):
+        model = ET.Element("Model")
+        add_hunt_crossley_force(
+            model, name="f1", contact_geometry_1="a", contact_geometry_2="b"
+        )
+        add_hunt_crossley_force(
+            model, name="f2", contact_geometry_1="c", contact_geometry_2="d"
+        )
+        force_sets = model.findall("ForceSet")
+        assert len(force_sets) == 1
+        assert len(force_sets[0]) == 2
+
+
+class TestExerciseModelGroundContact:
+    """Integration tests: verify contact elements appear in built models."""
+
+    def test_squat_has_contact_geometry_set(self):
+        xml_str = SquatModelBuilder().build()
+        root = ET.fromstring(xml_str)
+        cg_set = root.find(".//ContactGeometrySet")
+        assert cg_set is not None
+
+    def test_squat_has_ground_half_space(self):
+        xml_str = SquatModelBuilder().build()
+        root = ET.fromstring(xml_str)
+        half_space = root.find(".//ContactHalfSpace[@name='ground_contact']")
+        assert half_space is not None
+
+    def test_squat_has_eight_foot_contact_spheres(self):
+        xml_str = SquatModelBuilder().build()
+        root = ET.fromstring(xml_str)
+        spheres = root.findall(".//ContactSphere")
+        # 8 foot contact spheres (4 per foot)
+        assert len(spheres) == 8
+
+    def test_squat_has_hunt_crossley_forces(self):
+        xml_str = SquatModelBuilder().build()
+        root = ET.fromstring(xml_str)
+        forces = root.findall(".//HuntCrossleyForce")
+        # 8 forces (one per foot contact sphere)
+        assert len(forces) == 8
+
+    def test_squat_force_set_exists(self):
+        xml_str = SquatModelBuilder().build()
+        root = ET.fromstring(xml_str)
+        force_set = root.find(".//ForceSet")
+        assert force_set is not None
+
+    def test_bench_press_has_bench_contact(self):
+        xml_str = BenchPressModelBuilder().build()
+        root = ET.fromstring(xml_str)
+        bench_half_space = root.find(".//ContactHalfSpace[@name='bench_contact']")
+        assert bench_half_space is not None
+
+    def test_bench_press_has_pelvis_contact_sphere(self):
+        xml_str = BenchPressModelBuilder().build()
+        root = ET.fromstring(xml_str)
+        pelvis_sphere = root.find(".//ContactSphere[@name='pelvis_contact']")
+        assert pelvis_sphere is not None
+
+    def test_bench_press_has_pelvis_bench_force(self):
+        xml_str = BenchPressModelBuilder().build()
+        root = ET.fromstring(xml_str)
+        force = root.find(".//HuntCrossleyForce[@name='force_pelvis_bench']")
+        assert force is not None
+
+    def test_bench_press_total_contact_spheres(self):
+        xml_str = BenchPressModelBuilder().build()
+        root = ET.fromstring(xml_str)
+        spheres = root.findall(".//ContactSphere")
+        # 8 foot + 1 pelvis = 9
+        assert len(spheres) == 9
+
+    def test_bench_press_total_forces(self):
+        xml_str = BenchPressModelBuilder().build()
+        root = ET.fromstring(xml_str)
+        forces = root.findall(".//HuntCrossleyForce")
+        # 8 foot + 1 pelvis-bench = 9
+        assert len(forces) == 9


### PR DESCRIPTION
## Summary
- Add `add_contact_half_space()`, `add_contact_sphere()`, and `add_hunt_crossley_force()` XML helpers to `xml_helpers.py`
- All exercise models now automatically include ground contact geometry: a ContactHalfSpace for the ground plane plus 8 ContactSphere elements (4 per foot: heel medial/lateral, toe medial/lateral) with HuntCrossleyForce connections
- Bench press model adds bench-pelvis contact via a second ContactHalfSpace at bench height and a pelvis ContactSphere

## Test plan
- [x] 24 new unit/integration tests in `test_ground_contact.py`
- [x] Verify ContactGeometrySet present in generated XML
- [x] Verify 8 foot contact spheres per model (4 per foot)
- [x] Verify HuntCrossleyForce elements exist for each sphere
- [x] Verify ground half-space is present
- [x] Verify bench press has bench contact surface and pelvis contact
- [x] Full test suite passes (262 tests, 93.6% coverage)
- [x] `ruff check` passes on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)