### PR TITLE
fix(ci): standardize fleet CI versions

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           python-version: "3.11"
           cache: 'pip'
-      - run: pip install ruff==0.14.10 mypy>=1.15.0 bandit==1.7.7
+      - run: pip install ruff==0.14.10 mypy==1.13.0 bandit==1.7.7
 
       - name: Lint
         run: ruff check src scripts tests


### PR DESCRIPTION
## Fixes
- Pin mypy to `==1.13.0` (was `>=1.15.0`) for fleet-wide consistency
- actions/checkout, actions/setup-python already at @v6
- pip-audit already present
- No duplicate black/ruff formatting steps found

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>