### PR TITLE
fix: use lazy %-formatting in logger.debug call in theme.py

### DIFF
--- a/src/opensim_models/shared/theme.py
+++ b/src/opensim_models/shared/theme.py
@@ -17,7 +17,7 @@ try:
         """Apply the global shared plot theme to a Matplotlib axis."""
         _style_axis(ax)
 
-    logger.debug(f"Loaded shared plot theme: {theme.name}")
+    logger.debug("Loaded shared plot theme: %s", theme.name)
 
 except ImportError:
     logger.warning(


### PR DESCRIPTION
## Summary
- Replace f-string with `%s`-style lazy formatting in the `logger.debug()` call in `theme.py` (line 20)
- This resolves the ruff LOG rule violation flagged in the issue

Closes #76

## Test plan
- [x] `ruff check` passes with zero violations
- [x] `ruff format --check` passes with zero diffs
- [x] All 397 tests pass

Generated with [Claude Code](https://claude.com/claude-code)