### PR TITLE
fix: add missing .gitignore entries and ignore stale root files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,11 @@ venv/
 .DS_Store
 Thumbs.db
 .hypothesis/
+.benchmarks/
+*.osim
+
+# Stale root files (one-off scripts / debug artifacts)
+fix_mypy.py
+mypy2.txt
+os_issues.json
+.ci_trigger.py


### PR DESCRIPTION
## Summary
- Add `.benchmarks/` and `*.osim` to `.gitignore`
- Add stale root-level one-off scripts/debug artifacts to `.gitignore`: `fix_mypy.py`, `mypy2.txt`, `os_issues.json`, `.ci_trigger.py`
- Note: `gh_run.log` and `gh_run_2.log` are already covered by the existing `*.log` pattern

Closes #79

## Test plan
- [ ] Verify `.gitignore` entries match the items listed in #79
- [ ] Confirm no tracked files were accidentally removed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)