### PR TITLE
fix: A-N Assessment remediation — DRY, LoD, DbC (#104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2026-03-30
+
+### Changed
+
+- **DRY**: Refactored `create_barbell_bodies` (was >80 lines) into three private helper functions: `_compute_sleeve_inertia`, `_add_barbell_bodies`, and `_add_sleeve_weld_joints`.
+- **LoD**: Added `body_spec`, `barbell_spec`, `gravity`, and `grip_offset` properties to `ExerciseModelBuilder` so subclasses and `build()` no longer reach two levels deep into `self.config.*`.
+- **LoD**: Updated `deadlift_model.py`, `bench_press_model.py`, and `squat_model.py` to use the new interface properties.
+- **DbC**: Added input validation to `main()` in `__main__.py` — `--mass`, `--height`, and `--plates` now fail fast with a descriptive error if out of range.
+
 ## [0.1.0] - 2026-03-22
 
 ### Added

--- a/src/opensim_models/__main__.py
+++ b/src/opensim_models/__main__.py
@@ -56,6 +56,14 @@ def main(argv: list[str] | None = None) -> None:
     """Run the CLI."""
     args = _build_parser().parse_args(argv)
 
+    # DbC: validate numeric arguments before constructing any model objects
+    if args.mass <= 0:
+        sys.exit(f"--mass must be positive, got {args.mass}")
+    if args.height <= 0:
+        sys.exit(f"--height must be positive, got {args.height}")
+    if args.plates < 0:
+        sys.exit(f"--plates must be non-negative, got {args.plates}")
+
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.WARNING,
         format="%(name)s %(levelname)s: %(message)s",

--- a/src/opensim_models/exercises/base.py
+++ b/src/opensim_models/exercises/base.py
@@ -111,6 +111,30 @@ class ExerciseModelBuilder(ABC):
     def __init__(self, config: ExerciseConfig | None = None) -> None:
         self.config = config or ExerciseConfig()
 
+    # --- LoD interface properties ---
+    # Callers (including subclasses) should use these accessors rather than
+    # reaching two levels deep into self.config.<field>.
+
+    @property
+    def body_spec(self) -> BodyModelSpec:
+        """Body model specification (LoD: avoids self.config.body_spec)."""
+        return self.config.body_spec
+
+    @property
+    def barbell_spec(self) -> BarbellSpec:
+        """Barbell specification (LoD: avoids self.config.barbell_spec)."""
+        return self.config.barbell_spec
+
+    @property
+    def gravity(self) -> tuple[float, float, float]:
+        """Gravity vector (LoD: avoids self.config.gravity)."""
+        return self.config.gravity
+
+    @property
+    def grip_offset(self) -> float:
+        """Grip offset in metres (LoD: avoids self.config.grip_offset)."""
+        return self.config.grip_offset
+
     @property
     @abstractmethod
     def exercise_name(self) -> str:
@@ -177,7 +201,7 @@ class ExerciseModelBuilder(ABC):
 
         # Gravity
         gravity = ET.SubElement(model, "gravity")
-        g = self.config.gravity
+        g = self.gravity
         gravity.text = f"{g[0]:.6f} {g[1]:.6f} {g[2]:.6f}"
 
         # Ground body
@@ -193,16 +217,14 @@ class ExerciseModelBuilder(ABC):
         body_bodies = create_full_body(
             bodyset,
             jointset,
-            self.config.body_spec,
+            self.body_spec,
             skip_ground_joint=self._skip_ground_joint(),
         )
 
         # Build barbell (only for exercises that use one)
         barbell_bodies: dict[str, ET.Element] = {}
         if self.uses_barbell:
-            barbell_bodies = create_barbell_bodies(
-                bodyset, jointset, self.config.barbell_spec
-            )
+            barbell_bodies = create_barbell_bodies(bodyset, jointset, self.barbell_spec)
 
         # Subclass hook: inject extra bodies/joints before barbell attachment
         self._pre_attach_hook(bodyset, jointset)
@@ -215,7 +237,7 @@ class ExerciseModelBuilder(ABC):
 
         # --- Ground contact geometry and forces ---
         add_contact_half_space(model, name="ground_contact", body="ground")
-        add_foot_contact_spheres(model, self.config.body_spec)
+        add_foot_contact_spheres(model, self.body_spec)
 
         # Connect each foot contact sphere to the ground half-space
         foot_contact_names = [

--- a/src/opensim_models/exercises/bench_press/bench_press_model.py
+++ b/src/opensim_models/exercises/bench_press/bench_press_model.py
@@ -143,7 +143,7 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
         The grip is approximately shoulder-width (~0.40 m from center
         on each side for a standard grip).
         """
-        attach_barbell_to_hands(jointset, self.config.grip_offset)
+        attach_barbell_to_hands(jointset, self.grip_offset)
 
     def _skip_ground_joint(self) -> bool:
         """Bench press supplies its own pelvis parent via WeldJoint to bench."""

--- a/src/opensim_models/exercises/deadlift/deadlift_model.py
+++ b/src/opensim_models/exercises/deadlift/deadlift_model.py
@@ -64,7 +64,7 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
         Note: variable names use the ``_y`` suffix because OpenSim uses a
         Y-up coordinate system (gravity acts in the -Y direction).
         """
-        h = self.config.body_spec.height
+        h = self.body_spec.height
         # Approx Winter (2009) fractions
         shank = h * 0.246
         thigh = h * 0.245
@@ -95,7 +95,7 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
 
         Grip is slightly outside the knees (~0.22 m from center).
         """
-        attach_barbell_to_hands(jointset, self.config.grip_offset)
+        attach_barbell_to_hands(jointset, self.grip_offset)
 
     def set_initial_pose(self, jointset: ET.Element) -> None:
         """Set the starting position: deep hip hinge, knees flexed.

--- a/src/opensim_models/exercises/squat/squat_model.py
+++ b/src/opensim_models/exercises/squat/squat_model.py
@@ -52,7 +52,7 @@ class SquatModelBuilder(ExerciseModelBuilder):
         Precondition: 'barbell_shaft' exists in barbell_bodies.
         """
         # Torso length from spec (approx 0.504 m for 1.75 m person)
-        torso_len = self.config.body_spec.height * 0.288
+        torso_len = self.body_spec.height * 0.288
         # High-bar position: top of torso minus ~3 cm
         trap_height = torso_len - 0.03
 

--- a/src/opensim_models/shared/barbell/barbell_model.py
+++ b/src/opensim_models/shared/barbell/barbell_model.py
@@ -119,6 +119,122 @@ class BarbellSpec:
         )
 
 
+def _compute_sleeve_inertia(
+    spec: BarbellSpec,
+) -> tuple[float, float, float]:
+    """Compute the combined inertia tuple for one loaded sleeve.
+
+    DRY helper: extracted from create_barbell_bodies to keep that function
+    under the 80-line threshold.
+
+    Returns:
+        (Ixx, Iyy, Izz) for the sleeve including any loaded plates.
+    """
+    sleeve_inertia = hollow_cylinder_inertia_along_x(
+        spec.sleeve_mass,
+        inner_radius=spec.sleeve_inner_radius,
+        outer_radius=spec.sleeve_radius,
+        length=spec.sleeve_length,
+    )
+    if spec.plate_mass_per_side > 0:
+        # Standard plate radius is 0.225 m (450 mm diameter)
+        plate_inertia = hollow_cylinder_inertia_along_x(
+            spec.plate_mass_per_side,
+            inner_radius=spec.sleeve_radius,
+            outer_radius=0.225,
+            length=max(0.01, spec.plate_mass_per_side * 0.002),
+        )
+        sleeve_inertia = (
+            sleeve_inertia[0] + plate_inertia[0],
+            sleeve_inertia[1] + plate_inertia[1],
+            sleeve_inertia[2] + plate_inertia[2],
+        )
+    return sleeve_inertia
+
+
+def _add_barbell_bodies(
+    bodyset: ET.Element,
+    spec: BarbellSpec,
+    shaft_name: str,
+    left_name: str,
+    right_name: str,
+    sleeve_inertia: tuple[float, float, float],
+) -> tuple[ET.Element, ET.Element, ET.Element]:
+    """Add shaft and sleeve body elements to *bodyset*.
+
+    DRY helper: extracted from create_barbell_bodies.
+
+    Returns:
+        (shaft_body, left_body, right_body) XML elements.
+    """
+    shaft_inertia = cylinder_inertia_along_x(
+        spec.shaft_mass, spec.shaft_radius, spec.shaft_length
+    )
+    sleeve_total_mass = spec.sleeve_mass + spec.plate_mass_per_side
+
+    shaft_body = add_body(
+        bodyset,
+        name=shaft_name,
+        mass=spec.shaft_mass,
+        mass_center=(0, 0, 0),
+        inertia_xx=shaft_inertia[0],
+        inertia_yy=shaft_inertia[1],
+        inertia_zz=shaft_inertia[2],
+    )
+    left_body = add_body(
+        bodyset,
+        name=left_name,
+        mass=sleeve_total_mass,
+        mass_center=(0, 0, 0),
+        inertia_xx=sleeve_inertia[0],
+        inertia_yy=sleeve_inertia[1],
+        inertia_zz=sleeve_inertia[2],
+    )
+    right_body = add_body(
+        bodyset,
+        name=right_name,
+        mass=sleeve_total_mass,
+        mass_center=(0, 0, 0),
+        inertia_xx=sleeve_inertia[0],
+        inertia_yy=sleeve_inertia[1],
+        inertia_zz=sleeve_inertia[2],
+    )
+    return shaft_body, left_body, right_body
+
+
+def _add_sleeve_weld_joints(
+    jointset: ET.Element,
+    spec: BarbellSpec,
+    prefix: str,
+    shaft_name: str,
+    left_name: str,
+    right_name: str,
+) -> None:
+    """Weld left and right sleeves to the shaft.
+
+    DRY helper: extracted from create_barbell_bodies.
+    """
+    half_shaft = spec.shaft_length / 2.0
+    half_sleeve = spec.sleeve_length / 2.0
+
+    add_weld_joint(
+        jointset,
+        name=f"{prefix}_left_weld",
+        parent_body=shaft_name,
+        child_body=left_name,
+        location_in_parent=(-half_shaft, 0, 0),
+        location_in_child=(half_sleeve, 0, 0),
+    )
+    add_weld_joint(
+        jointset,
+        name=f"{prefix}_right_weld",
+        parent_body=shaft_name,
+        child_body=right_name,
+        location_in_parent=(half_shaft, 0, 0),
+        location_in_child=(-half_sleeve, 0, 0),
+    )
+
+
 def create_barbell_bodies(
     bodyset: ET.Element,
     jointset: ET.Element,
@@ -132,92 +248,21 @@ def create_barbell_bodies(
 
     The barbell shaft center is at the local origin. Sleeves extend
     symmetrically along the X-axis (left = -X, right = +X).
+
+    DbC preconditions are enforced by BarbellSpec.__post_init__.
     """
+    require_positive(spec.total_mass, "spec.total_mass")
     logger.info("Creating barbell: %.1f kg total", spec.total_mass)
-    shaft_inertia = cylinder_inertia_along_x(
-        spec.shaft_mass, spec.shaft_radius, spec.shaft_length
-    )
-
-    # Compute inertia for bare sleeve (axis along X)
-    sleeve_inertia = hollow_cylinder_inertia_along_x(
-        spec.sleeve_mass,
-        inner_radius=spec.sleeve_inner_radius,
-        outer_radius=spec.sleeve_radius,
-        length=spec.sleeve_length,
-    )
-
-    if spec.plate_mass_per_side > 0:
-        # Standard plate radius is 0.225m (450mm diameter)
-        plate_inertia = hollow_cylinder_inertia_along_x(
-            spec.plate_mass_per_side,
-            inner_radius=spec.sleeve_radius,
-            outer_radius=0.225,
-            length=max(
-                0.01, spec.plate_mass_per_side * 0.002
-            ),  # approximate plate thickness
-        )
-        sleeve_inertia = (
-            sleeve_inertia[0] + plate_inertia[0],
-            sleeve_inertia[1] + plate_inertia[1],
-            sleeve_inertia[2] + plate_inertia[2],
-        )
-
-    sleeve_total_mass = spec.sleeve_mass + spec.plate_mass_per_side
 
     shaft_name = f"{prefix}_shaft"
     left_name = f"{prefix}_left_sleeve"
     right_name = f"{prefix}_right_sleeve"
 
-    shaft_body = add_body(
-        bodyset,
-        name=shaft_name,
-        mass=spec.shaft_mass,
-        mass_center=(0, 0, 0),
-        inertia_xx=shaft_inertia[0],
-        inertia_yy=shaft_inertia[1],
-        inertia_zz=shaft_inertia[2],
+    sleeve_inertia = _compute_sleeve_inertia(spec)
+    shaft_body, left_body, right_body = _add_barbell_bodies(
+        bodyset, spec, shaft_name, left_name, right_name, sleeve_inertia
     )
-
-    left_body = add_body(
-        bodyset,
-        name=left_name,
-        mass=sleeve_total_mass,
-        mass_center=(0, 0, 0),
-        inertia_xx=sleeve_inertia[0],
-        inertia_yy=sleeve_inertia[1],
-        inertia_zz=sleeve_inertia[2],
-    )
-
-    right_body = add_body(
-        bodyset,
-        name=right_name,
-        mass=sleeve_total_mass,
-        mass_center=(0, 0, 0),
-        inertia_xx=sleeve_inertia[0],
-        inertia_yy=sleeve_inertia[1],
-        inertia_zz=sleeve_inertia[2],
-    )
-
-    half_shaft = spec.shaft_length / 2.0
-    half_sleeve = spec.sleeve_length / 2.0
-
-    add_weld_joint(
-        jointset,
-        name=f"{prefix}_left_weld",
-        parent_body=shaft_name,
-        child_body=left_name,
-        location_in_parent=(-half_shaft, 0, 0),
-        location_in_child=(half_sleeve, 0, 0),
-    )
-
-    add_weld_joint(
-        jointset,
-        name=f"{prefix}_right_weld",
-        parent_body=shaft_name,
-        child_body=right_name,
-        location_in_parent=(half_shaft, 0, 0),
-        location_in_child=(-half_sleeve, 0, 0),
-    )
+    _add_sleeve_weld_joints(jointset, spec, prefix, shaft_name, left_name, right_name)
 
     return {
         shaft_name: shaft_body,


### PR DESCRIPTION
## Summary

- **DRY**: Refactored `create_barbell_bodies` (was >80 lines) into three focused private helpers: `_compute_sleeve_inertia`, `_add_barbell_bodies`, `_add_sleeve_weld_joints`
- **LoD**: Added `body_spec`, `barbell_spec`, `gravity`, and `grip_offset` interface properties to `ExerciseModelBuilder`; updated `build()`, `deadlift_model.py`, `bench_press_model.py`, and `squat_model.py` to stop reaching into `self.config.*` directly
- **DbC**: Added input validation in `main()` (`__main__.py`) — `--mass`, `--height`, `--plates` now fail fast with descriptive messages before any model construction

Closes #104

## Test plan

- [x] `ruff check` — zero violations
- [x] `ruff format --check` — zero diffs
- [x] `mypy src` — zero errors
- [x] `pytest` — 425 passed, 94.88% coverage (above 80% floor)