### PR TITLE
refactor: break down 13 functions exceeding 50-line limit

### DIFF
--- a/src/opensim_models/exercises/base.py
+++ b/src/opensim_models/exercises/base.py
@@ -190,30 +190,30 @@ class ExerciseModelBuilder(ABC):
         The default implementation is a no-op.
         """
 
-    def build(self) -> str:
-        """Build the complete OpenSim model XML and return as string.
-
-        Postcondition: returned string is well-formed XML.
-        """
-        logger.info("Building %s model", self.exercise_name)
+    def _create_model_root(self) -> tuple[ET.Element, ET.Element]:
+        """Create the OpenSim document root and Model element."""
         root = ET.Element("OpenSimDocument", Version="40500")
         model = ET.SubElement(root, "Model", name=self.exercise_name)
+        return root, model
 
-        # Gravity
+    def _add_gravity_and_ground(self, model: ET.Element) -> None:
+        """Append gravity vector and massless Ground body to the model."""
         gravity = ET.SubElement(model, "gravity")
         g = self.gravity
         gravity.text = f"{g[0]:.6f} {g[1]:.6f} {g[2]:.6f}"
 
-        # Ground body
         ground_el = ET.SubElement(model, "Ground", name="ground")
         ET.SubElement(ground_el, "mass").text = "0"
         ET.SubElement(ground_el, "mass_center").text = "0 0 0"
         ET.SubElement(ground_el, "inertia").text = "0 0 0 0 0 0"
 
+    def _build_bodies_and_joints(
+        self, model: ET.Element
+    ) -> tuple[ET.Element, ET.Element, dict[str, ET.Element], dict[str, ET.Element]]:
+        """Build body/joint sets, populate them, and return the sets and body dicts."""
         bodyset = ET.SubElement(model, "BodySet")
         jointset = ET.SubElement(model, "JointSet")
 
-        # Build body (skip the ground FreeJoint when subclass requests it)
         body_bodies = create_full_body(
             bodyset,
             jointset,
@@ -221,25 +221,17 @@ class ExerciseModelBuilder(ABC):
             skip_ground_joint=self._skip_ground_joint(),
         )
 
-        # Build barbell (only for exercises that use one)
         barbell_bodies: dict[str, ET.Element] = {}
         if self.uses_barbell:
             barbell_bodies = create_barbell_bodies(bodyset, jointset, self.barbell_spec)
 
-        # Subclass hook: inject extra bodies/joints before barbell attachment
-        self._pre_attach_hook(bodyset, jointset)
+        return bodyset, jointset, body_bodies, barbell_bodies
 
-        # Exercise-specific attachment
-        self.attach_barbell(jointset, body_bodies, barbell_bodies)
-
-        # Exercise-specific initial pose
-        self.set_initial_pose(jointset)
-
-        # --- Ground contact geometry and forces ---
+    def _add_ground_contact(self, model: ET.Element) -> None:
+        """Add the ground contact half-space and foot sphere forces."""
         add_contact_half_space(model, name="ground_contact", body="ground")
         add_foot_contact_spheres(model, self.body_spec)
 
-        # Connect each foot contact sphere to the ground half-space
         foot_contact_names = [
             f"foot_{side}_{point}"
             for side in ("l", "r")
@@ -253,7 +245,28 @@ class ExerciseModelBuilder(ABC):
                 contact_geometry_2="ground_contact",
             )
 
-        # Subclass hook for additional contact surfaces
+    def build(self) -> str:
+        """Build the complete OpenSim model XML and return as string.
+
+        Postcondition: returned string is well-formed XML.
+        """
+        logger.info("Building %s model", self.exercise_name)
+        root, model = self._create_model_root()
+        self._add_gravity_and_ground(model)
+
+        bodyset, jointset, body_bodies, barbell_bodies = self._build_bodies_and_joints(
+            model
+        )
+
+        # Subclass hook: inject extra bodies/joints before barbell attachment
+        self._pre_attach_hook(bodyset, jointset)
+
+        # Exercise-specific attachment and initial pose
+        self.attach_barbell(jointset, body_bodies, barbell_bodies)
+        self.set_initial_pose(jointset)
+
+        # Ground contact geometry and forces, plus subclass hook
+        self._add_ground_contact(model)
         self._post_contact_hook(model)
 
         xml_str = serialize_model(root)

--- a/src/opensim_models/exercises/bench_press/bench_press_model.py
+++ b/src/opensim_models/exercises/bench_press/bench_press_model.py
@@ -67,22 +67,11 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
     def exercise_name(self) -> str:
         return "bench_press"
 
-    def _add_bench_and_constraint(
-        self,
-        bodyset: ET.Element,
-        jointset: ET.Element,
-    ) -> None:
-        """Add the bench body welded to ground and pelvis welded to bench.
-
-        The bench sits at BENCH_HEIGHT. The pelvis is constrained supine
-        (face-up): the Z-axis of the pelvis points up (+Z = superior when
-        lying on back), so orientation is rotated 90° about X to go from
-        the default standing Y-up to the supine Z-up posture.
-        """
+    def _add_bench_body(self, bodyset: ET.Element) -> None:
+        """Add the bench rigid body to *bodyset* with near-zero mass."""
         bench_inertia = rectangular_prism_inertia(
             _BENCH_MASS, _BENCH_WIDTH, _BENCH_HEIGHT_DIM, _BENCH_DEPTH
         )
-
         add_body(
             bodyset,
             name="bench",
@@ -93,7 +82,8 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
             inertia_zz=bench_inertia[2],
         )
 
-        # Weld bench to ground at bench height (top surface of bench at BENCH_HEIGHT)
+    def _weld_bench_to_ground(self, jointset: ET.Element) -> None:
+        """Weld the bench body to ground at BENCH_HEIGHT."""
         add_weld_joint(
             jointset,
             name="bench_to_ground",
@@ -103,9 +93,12 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
             location_in_child=(0, 0, 0),
         )
 
-        # Weld pelvis to bench in supine orientation.
-        # Supine: lifter lies face-up; pelvis Y-axis (long axis when standing)
-        # becomes the Z-axis. Rotate 90° about X (pi/2) to achieve this.
+    def _weld_pelvis_to_bench_supine(self, jointset: ET.Element) -> None:
+        """Weld pelvis to bench and patch child frame to supine orientation.
+
+        Supine: lifter lies face-up; pelvis Y-axis (long axis when standing)
+        becomes the Z-axis. Rotate 90° about X (pi/2) to achieve this.
+        """
         add_weld_joint(
             jointset,
             name="pelvis_to_bench",
@@ -114,23 +107,27 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
             location_in_parent=(0, 0, 0),
             location_in_child=(0, 0, 0),
         )
-        # Set supine orientation on the pelvis_to_bench child frame
-        # by patching the child frame orientation after creation.
-        # Rotate 90° about X-axis: (pi/2, 0, 0) places pelvis in supine (face-up) pose.
         supine_orient = f"{math.pi / 2:.6f} 0.000000 0.000000"
-        bench_pelvis_joint = None
         for j in jointset.findall("WeldJoint"):
             if j.get("name") == "pelvis_to_bench":
-                bench_pelvis_joint = j
+                child_frame = j.find(
+                    "PhysicalOffsetFrame[@name='pelvis_to_bench_child']"
+                )
+                if child_frame is not None:
+                    orient_el = child_frame.find("orientation")
+                    if orient_el is not None:
+                        orient_el.text = supine_orient
                 break
-        if bench_pelvis_joint is not None:
-            child_frame = bench_pelvis_joint.find(
-                "PhysicalOffsetFrame[@name='pelvis_to_bench_child']"
-            )
-            if child_frame is not None:
-                orient_el = child_frame.find("orientation")
-                if orient_el is not None:
-                    orient_el.text = supine_orient
+
+    def _add_bench_and_constraint(
+        self,
+        bodyset: ET.Element,
+        jointset: ET.Element,
+    ) -> None:
+        """Add the bench body welded to ground and pelvis welded to bench."""
+        self._add_bench_body(bodyset)
+        self._weld_bench_to_ground(jointset)
+        self._weld_pelvis_to_bench_supine(jointset)
 
     def attach_barbell(
         self,

--- a/src/opensim_models/optimization/trajectory_optimizer.py
+++ b/src/opensim_models/optimization/trajectory_optimizer.py
@@ -69,6 +69,33 @@ class TrajectoryResult:
     config: TrajectoryConfig | None = None
 
 
+def _collect_coords(objective: ExerciseObjective) -> set[str]:
+    """Return all coordinate names referenced across all phases."""
+    all_coords: set[str] = set()
+    for phase in objective.phases:
+        all_coords.update(phase.joint_targets.keys())
+    return all_coords
+
+
+def _interpolate_coord(
+    coord: str,
+    objective: ExerciseObjective,
+    normalised: np.ndarray,
+    num_points: int,
+) -> np.ndarray:
+    """Return a linearly interpolated trajectory array for one coordinate."""
+    wp_times: list[float] = []
+    wp_values: list[float] = []
+    for phase in objective.phases:
+        if coord in phase.joint_targets:
+            wp_times.append(phase.time_fraction)
+            wp_values.append(phase.joint_targets[coord])
+
+    if len(wp_times) < 2:
+        return np.full(num_points, wp_values[0] if wp_values else 0.0)
+    return np.interp(normalised, wp_times, wp_values)
+
+
 def interpolate_phases(
     objective: ExerciseObjective,
     num_points: int = 100,
@@ -95,26 +122,10 @@ def interpolate_phases(
     time = np.linspace(0.0, duration, num_points)
     normalised = time / duration  # [0, 1]
 
-    # Collect all coordinate names across all phases
-    all_coords: set[str] = set()
-    for phase in objective.phases:
-        all_coords.update(phase.joint_targets.keys())
-
-    coordinates: dict[str, np.ndarray] = {}
-    for coord in sorted(all_coords):
-        # Build waypoint arrays for this coordinate
-        wp_times: list[float] = []
-        wp_values: list[float] = []
-        for phase in objective.phases:
-            if coord in phase.joint_targets:
-                wp_times.append(phase.time_fraction)
-                wp_values.append(phase.joint_targets[coord])
-
-        if len(wp_times) < 2:
-            # Single waypoint: constant value
-            coordinates[coord] = np.full(num_points, wp_values[0] if wp_values else 0.0)
-        else:
-            coordinates[coord] = np.interp(normalised, wp_times, wp_values)
+    coordinates: dict[str, np.ndarray] = {
+        coord: _interpolate_coord(coord, objective, normalised, num_points)
+        for coord in sorted(_collect_coords(objective))
+    }
 
     return TrajectoryResult(
         time=time,
@@ -123,6 +134,34 @@ def interpolate_phases(
         objective_value=0.0,
         iterations=0,
     )
+
+
+def _build_solver_dict(config: TrajectoryConfig) -> dict:
+    """Return the MocoCasADiSolver sub-dict for a Moco study."""
+    return {
+        "type": "MocoCasADiSolver",
+        "max_iterations": config.max_iterations,
+        "convergence_tolerance": config.convergence_tolerance,
+        "constraint_tolerance": config.constraint_tolerance,
+        "num_mesh_intervals": config.num_mesh_points,
+    }
+
+
+def _build_problem_dict(
+    config: TrajectoryConfig,
+    objective: ExerciseObjective,
+    guess: TrajectoryResult,
+) -> dict:
+    """Return the problem definition sub-dict for a Moco study."""
+    return {
+        "exercise": objective.name,
+        "duration": config.duration,
+        "coordinates": list(guess.coordinates.keys()),
+        "cost_weights": {
+            "tracking": config.weight_tracking,
+            "effort": config.weight_effort,
+        },
+    }
 
 
 def create_moco_study(config: TrajectoryConfig) -> dict:
@@ -155,22 +194,8 @@ def create_moco_study(config: TrajectoryConfig) -> dict:
     )
 
     return {
-        "solver": {
-            "type": "MocoCasADiSolver",
-            "max_iterations": config.max_iterations,
-            "convergence_tolerance": config.convergence_tolerance,
-            "constraint_tolerance": config.constraint_tolerance,
-            "num_mesh_intervals": config.num_mesh_points,
-        },
-        "problem": {
-            "exercise": objective.name,
-            "duration": config.duration,
-            "coordinates": list(guess.coordinates.keys()),
-            "cost_weights": {
-                "tracking": config.weight_tracking,
-                "effort": config.weight_effort,
-            },
-        },
+        "solver": _build_solver_dict(config),
+        "problem": _build_problem_dict(config, objective, guess),
         "initial_guess": {
             "time": guess.time.tolist(),
             "coordinates": {k: v.tolist() for k, v in guess.coordinates.items()},

--- a/src/opensim_models/shared/body/axial_skeleton.py
+++ b/src/opensim_models/shared/body/axial_skeleton.py
@@ -56,31 +56,33 @@ def add_axial_body(
     return mass, length, radius
 
 
-def add_axial_joints(
-    jointset: ET.Element,
-    spec: BodyModelSpec,
-    p_len: float,
-    t_len: float,
-    *,
-    skip_ground_joint: bool,
-) -> None:
-    """Add the axial skeleton joints (ground-pelvis, lumbar, neck)."""
+def _compute_pelvis_height(spec: BodyModelSpec, p_len: float) -> float:
+    """Derive standing pelvis height from lower-limb segment lengths."""
     _, thigh_len, _ = _seg(spec, "thigh")
     _, shank_len, _ = _seg(spec, "shank")
     _, foot_len, _ = _seg(spec, "foot")
-    pelvis_height = thigh_len + shank_len + foot_len + p_len / 2.0
-    logger.debug("Derived pelvis height: %.4f m", pelvis_height)
+    return thigh_len + shank_len + foot_len + p_len / 2.0
 
-    if not skip_ground_joint:
-        add_free_joint(
-            jointset,
-            name="ground_pelvis",
-            parent_body="ground",
-            child_body="pelvis",
-            location_in_parent=(0, pelvis_height, 0),
-        )
 
-    # Lumbar: BallJoint connecting pelvis to torso
+def _add_ground_pelvis_joint(
+    jointset: ET.Element,
+    pelvis_height: float,
+) -> None:
+    """Add the 6-DOF FreeJoint connecting the ground to the pelvis."""
+    add_free_joint(
+        jointset,
+        name="ground_pelvis",
+        parent_body="ground",
+        child_body="pelvis",
+        location_in_parent=(0, pelvis_height, 0),
+    )
+
+
+def _add_lumbar_joint(
+    jointset: ET.Element,
+    p_len: float,
+) -> None:
+    """Add the 3-DOF BallJoint connecting pelvis to torso."""
     add_ball_joint(
         jointset,
         name="lumbar",
@@ -110,7 +112,12 @@ def add_axial_joints(
         ],
     )
 
-    # Neck: PinJoint connecting torso to head
+
+def _add_neck_joint(
+    jointset: ET.Element,
+    t_len: float,
+) -> None:
+    """Add the 1-DOF PinJoint connecting torso to head."""
     add_pin_joint(
         jointset,
         name="neck",
@@ -122,3 +129,22 @@ def add_axial_joints(
         range_min=-0.5236,
         range_max=0.5236,
     )
+
+
+def add_axial_joints(
+    jointset: ET.Element,
+    spec: BodyModelSpec,
+    p_len: float,
+    t_len: float,
+    *,
+    skip_ground_joint: bool,
+) -> None:
+    """Add the axial skeleton joints (ground-pelvis, lumbar, neck)."""
+    pelvis_height = _compute_pelvis_height(spec, p_len)
+    logger.debug("Derived pelvis height: %.4f m", pelvis_height)
+
+    if not skip_ground_joint:
+        _add_ground_pelvis_joint(jointset, pelvis_height)
+
+    _add_lumbar_joint(jointset, p_len)
+    _add_neck_joint(jointset, t_len)

--- a/src/opensim_models/shared/body/body_model.py
+++ b/src/opensim_models/shared/body/body_model.py
@@ -24,18 +24,15 @@ from opensim_models.shared.body.limb_builders import (
 logger = logging.getLogger(__name__)
 
 
-def _add_upper_limbs(
+def _add_upper_arm(
     bodyset: ET.Element,
     jointset: ET.Element,
     spec: BodyModelSpec,
-    t_len: float,
-    t_rad: float,
+    shoulder_y: float,
+    shoulder_x: float,
     bodies: dict[str, ET.Element],
 ) -> None:
-    """Add bilateral upper-limb segments (arms, forearms, hands)."""
-    shoulder_y = t_len * 0.95
-    shoulder_x = t_rad * 1.2
-
+    """Add bilateral upper-arm segments with 3-DOF shoulder ball joints."""
     add_bilateral_ball_joint_limb(
         bodyset,
         jointset,
@@ -54,6 +51,14 @@ def _add_upper_limbs(
         bodies=bodies,
     )
 
+
+def _add_forearm(
+    bodyset: ET.Element,
+    jointset: ET.Element,
+    spec: BodyModelSpec,
+    bodies: dict[str, ET.Element],
+) -> None:
+    """Add bilateral forearm segments with single-axis elbow pin joints."""
     _, ua_len, _ = _seg(spec, "upper_arm")
     add_bilateral_limb(
         bodyset,
@@ -69,6 +74,14 @@ def _add_upper_limbs(
         bodies=bodies,
     )
 
+
+def _add_hand(
+    bodyset: ET.Element,
+    jointset: ET.Element,
+    spec: BodyModelSpec,
+    bodies: dict[str, ET.Element],
+) -> None:
+    """Add bilateral hand segments with 2-DOF wrist custom joints."""
     _, fa_len, _ = _seg(spec, "forearm")
     add_bilateral_custom_joint_limb(
         bodyset,
@@ -97,17 +110,31 @@ def _add_upper_limbs(
     )
 
 
-def _add_lower_limbs(
+def _add_upper_limbs(
+    bodyset: ET.Element,
+    jointset: ET.Element,
+    spec: BodyModelSpec,
+    t_len: float,
+    t_rad: float,
+    bodies: dict[str, ET.Element],
+) -> None:
+    """Add bilateral upper-limb segments (arms, forearms, hands)."""
+    shoulder_y = t_len * 0.95
+    shoulder_x = t_rad * 1.2
+    _add_upper_arm(bodyset, jointset, spec, shoulder_y, shoulder_x, bodies)
+    _add_forearm(bodyset, jointset, spec, bodies)
+    _add_hand(bodyset, jointset, spec, bodies)
+
+
+def _add_thigh(
     bodyset: ET.Element,
     jointset: ET.Element,
     spec: BodyModelSpec,
     p_len: float,
-    p_rad: float,
+    hip_x: float,
     bodies: dict[str, ET.Element],
 ) -> None:
-    """Add bilateral lower-limb segments (thighs, shanks, feet)."""
-    hip_x = p_rad * 0.6
-
+    """Add bilateral thigh segments with 3-DOF hip ball joints."""
     add_bilateral_ball_joint_limb(
         bodyset,
         jointset,
@@ -126,6 +153,14 @@ def _add_lower_limbs(
         bodies=bodies,
     )
 
+
+def _add_shank(
+    bodyset: ET.Element,
+    jointset: ET.Element,
+    spec: BodyModelSpec,
+    bodies: dict[str, ET.Element],
+) -> None:
+    """Add bilateral shank segments with single-axis knee pin joints."""
     _, th_len, _ = _seg(spec, "thigh")
     add_bilateral_limb(
         bodyset,
@@ -141,6 +176,14 @@ def _add_lower_limbs(
         bodies=bodies,
     )
 
+
+def _add_foot(
+    bodyset: ET.Element,
+    jointset: ET.Element,
+    spec: BodyModelSpec,
+    bodies: dict[str, ET.Element],
+) -> None:
+    """Add bilateral foot segments with 2-DOF ankle custom joints."""
     _, sh_len, _ = _seg(spec, "shank")
     add_bilateral_custom_joint_limb(
         bodyset,
@@ -167,6 +210,21 @@ def _add_lower_limbs(
         ],
         bodies=bodies,
     )
+
+
+def _add_lower_limbs(
+    bodyset: ET.Element,
+    jointset: ET.Element,
+    spec: BodyModelSpec,
+    p_len: float,
+    p_rad: float,
+    bodies: dict[str, ET.Element],
+) -> None:
+    """Add bilateral lower-limb segments (thighs, shanks, feet)."""
+    hip_x = p_rad * 0.6
+    _add_thigh(bodyset, jointset, spec, p_len, hip_x, bodies)
+    _add_shank(bodyset, jointset, spec, bodies)
+    _add_foot(bodyset, jointset, spec, bodies)
 
 
 def create_full_body(

--- a/src/opensim_models/shared/body/limb_builders.py
+++ b/src/opensim_models/shared/body/limb_builders.py
@@ -25,6 +25,38 @@ from opensim_models.shared.utils.xml_helpers import (
 logger = logging.getLogger(__name__)
 
 
+def _resolve_parent_name(parent_name: str, side: str) -> str:
+    """Return the side-qualified parent name for bilateral segments."""
+    return (
+        f"{parent_name}_{side}" if parent_name in _BILATERAL_SEGMENTS else parent_name
+    )
+
+
+def _add_bilateral_body(
+    bodyset: ET.Element,
+    seg_name: str,
+    side: str,
+    mass: float,
+    length: float,
+    inertia: tuple[float, float, float],
+    bodies: dict[str, ET.Element] | None,
+) -> str:
+    """Add one side's body element and register it in *bodies*. Returns body name."""
+    body_name = f"{seg_name}_{side}"
+    body_el = add_body(
+        bodyset,
+        name=body_name,
+        mass=mass,
+        mass_center=(0, -length / 2.0, 0),
+        inertia_xx=inertia[0],
+        inertia_yy=inertia[1],
+        inertia_zz=inertia[2],
+    )
+    if bodies is not None:
+        bodies[body_name] = body_el
+    return body_name
+
+
 def add_bilateral_limb(
     bodyset: ET.Element,
     jointset: ET.Element,
@@ -44,26 +76,13 @@ def add_bilateral_limb(
     inertia = cylinder_inertia(mass, radius, length)
 
     for side, sign in [("l", -1.0), ("r", 1.0)]:
-        body_name = f"{seg_name}_{side}"
-        body_el = add_body(
-            bodyset,
-            name=body_name,
-            mass=mass,
-            mass_center=(0, -length / 2.0, 0),
-            inertia_xx=inertia[0],
-            inertia_yy=inertia[1],
-            inertia_zz=inertia[2],
+        body_name = _add_bilateral_body(
+            bodyset, seg_name, side, mass, length, inertia, bodies
         )
-        if bodies is not None:
-            bodies[body_name] = body_el
         add_pin_joint(
             jointset,
             name=f"{coord_prefix}_{side}",
-            parent_body=(
-                f"{parent_name}_{side}"
-                if parent_name in _BILATERAL_SEGMENTS
-                else parent_name
-            ),
+            parent_body=_resolve_parent_name(parent_name, side),
             child_body=body_name,
             location_in_parent=(sign * parent_lateral_x, parent_offset_y, 0),
             location_in_child=(0, 0, 0),
@@ -96,18 +115,9 @@ def add_bilateral_ball_joint_limb(
     inertia = cylinder_inertia(mass, radius, length)
 
     for side, sign in [("l", -1.0), ("r", 1.0)]:
-        body_name = f"{seg_name}_{side}"
-        body_el = add_body(
-            bodyset,
-            name=body_name,
-            mass=mass,
-            mass_center=(0, -length / 2.0, 0),
-            inertia_xx=inertia[0],
-            inertia_yy=inertia[1],
-            inertia_zz=inertia[2],
+        body_name = _add_bilateral_body(
+            bodyset, seg_name, side, mass, length, inertia, bodies
         )
-        if bodies is not None:
-            bodies[body_name] = body_el
         coordinates: list[dict[str, float | str]] = [
             {
                 "name": f"{coord_prefix}_{side}_{suffix}",
@@ -120,11 +130,7 @@ def add_bilateral_ball_joint_limb(
         add_ball_joint(
             jointset,
             name=f"{coord_prefix}_{side}",
-            parent_body=(
-                f"{parent_name}_{side}"
-                if parent_name in _BILATERAL_SEGMENTS
-                else parent_name
-            ),
+            parent_body=_resolve_parent_name(parent_name, side),
             child_body=body_name,
             location_in_parent=(sign * parent_lateral_x, parent_offset_y, 0),
             location_in_child=(0, 0, 0),
@@ -150,18 +156,9 @@ def add_bilateral_custom_joint_limb(
     inertia = cylinder_inertia(mass, radius, length)
 
     for side, sign in [("l", -1.0), ("r", 1.0)]:
-        body_name = f"{seg_name}_{side}"
-        body_el = add_body(
-            bodyset,
-            name=body_name,
-            mass=mass,
-            mass_center=(0, -length / 2.0, 0),
-            inertia_xx=inertia[0],
-            inertia_yy=inertia[1],
-            inertia_zz=inertia[2],
+        body_name = _add_bilateral_body(
+            bodyset, seg_name, side, mass, length, inertia, bodies
         )
-        if bodies is not None:
-            bodies[body_name] = body_el
         coordinates: list[dict[str, float | str]] = [
             {
                 "name": f"{coord_prefix}_{side}_{c['suffix']}",
@@ -175,11 +172,7 @@ def add_bilateral_custom_joint_limb(
         add_custom_joint(
             jointset,
             name=f"{coord_prefix}_{side}",
-            parent_body=(
-                f"{parent_name}_{side}"
-                if parent_name in _BILATERAL_SEGMENTS
-                else parent_name
-            ),
+            parent_body=_resolve_parent_name(parent_name, side),
             child_body=body_name,
             location_in_parent=(sign * parent_lateral_x, parent_offset_y, 0),
             location_in_child=(0, 0, 0),

--- a/src/opensim_models/shared/utils/xml_helpers.py
+++ b/src/opensim_models/shared/utils/xml_helpers.py
@@ -87,6 +87,45 @@ def add_pin_joint(
     return joint
 
 
+def _add_joint_frames(
+    joint: ET.Element,
+    name: str,
+    parent_body: str,
+    child_body: str,
+    location_in_parent: tuple[float, float, float],
+    location_in_child: tuple[float, float, float],
+    orientation_in_parent: tuple[float, float, float],
+    orientation_in_child: tuple[float, float, float],
+) -> None:
+    """Append parent and child PhysicalOffsetFrame elements to a joint."""
+    pf = ET.SubElement(joint, "PhysicalOffsetFrame", name=f"{name}_parent")
+    ET.SubElement(pf, "socket_parent").text = f"/bodyset/{parent_body}"
+    ET.SubElement(pf, "translation").text = vec3_str(*location_in_parent)
+    ET.SubElement(pf, "orientation").text = vec3_str(*orientation_in_parent)
+
+    cf = ET.SubElement(joint, "PhysicalOffsetFrame", name=f"{name}_child")
+    ET.SubElement(cf, "socket_parent").text = f"/bodyset/{child_body}"
+    ET.SubElement(cf, "translation").text = vec3_str(*location_in_child)
+    ET.SubElement(cf, "orientation").text = vec3_str(*orientation_in_child)
+
+    ET.SubElement(joint, "socket_parent_frame").text = f"{name}_parent"
+    ET.SubElement(joint, "socket_child_frame").text = f"{name}_child"
+
+
+def _add_coordinate_set(
+    joint: ET.Element,
+    coordinates: list[dict[str, float | str]],
+) -> None:
+    """Append a <coordinates> element with Coordinate children to a joint."""
+    coord_set = ET.SubElement(joint, "coordinates")
+    for c in coordinates:
+        coord = ET.SubElement(coord_set, "Coordinate", name=str(c["name"]))
+        ET.SubElement(coord, "default_value").text = f"{float(c['default_value']):.6f}"
+        ET.SubElement(
+            coord, "range"
+        ).text = f"{float(c['range_min']):.6f} {float(c['range_max']):.6f}"
+
+
 def add_ball_joint(
     jointset: ET.Element,
     *,
@@ -113,32 +152,34 @@ def add_ball_joint(
         )
 
     joint = ET.SubElement(jointset, "BallJoint", name=name)
-
-    # Parent frame
-    pf = ET.SubElement(joint, "PhysicalOffsetFrame", name=f"{name}_parent")
-    ET.SubElement(pf, "socket_parent").text = f"/bodyset/{parent_body}"
-    ET.SubElement(pf, "translation").text = vec3_str(*location_in_parent)
-    ET.SubElement(pf, "orientation").text = vec3_str(*orientation_in_parent)
-
-    # Child frame
-    cf = ET.SubElement(joint, "PhysicalOffsetFrame", name=f"{name}_child")
-    ET.SubElement(cf, "socket_parent").text = f"/bodyset/{child_body}"
-    ET.SubElement(cf, "translation").text = vec3_str(*location_in_child)
-    ET.SubElement(cf, "orientation").text = vec3_str(*orientation_in_child)
-
-    ET.SubElement(joint, "socket_parent_frame").text = f"{name}_parent"
-    ET.SubElement(joint, "socket_child_frame").text = f"{name}_child"
-
-    # CoordinateSet
-    coord_set = ET.SubElement(joint, "coordinates")
-    for c in coordinates:
-        coord = ET.SubElement(coord_set, "Coordinate", name=str(c["name"]))
-        ET.SubElement(coord, "default_value").text = f"{float(c['default_value']):.6f}"
-        ET.SubElement(
-            coord, "range"
-        ).text = f"{float(c['range_min']):.6f} {float(c['range_max']):.6f}"
-
+    _add_joint_frames(
+        joint,
+        name,
+        parent_body,
+        child_body,
+        location_in_parent,
+        location_in_child,
+        orientation_in_parent,
+        orientation_in_child,
+    )
+    _add_coordinate_set(joint, coordinates)
     return joint
+
+
+def _add_spatial_transform(
+    joint: ET.Element,
+    coordinates: list[dict[str, float | str]],
+) -> None:
+    """Append a <SpatialTransform> with TransformAxis elements to a CustomJoint."""
+    spatial = ET.SubElement(joint, "SpatialTransform")
+    rotation_axes = ["rotation1", "rotation2", "rotation3"]
+    translation_axes = ["translation1", "translation2", "translation3"]
+
+    for i, c in enumerate(coordinates):
+        axis_name = rotation_axes[i] if i < 3 else translation_axes[i - 3]
+        ta = ET.SubElement(spatial, "TransformAxis", name=axis_name)
+        ET.SubElement(ta, "coordinates").text = str(c["name"])
+        ET.SubElement(ta, "axis").text = str(c.get("axis", "0 0 1"))
 
 
 def add_custom_joint(
@@ -166,42 +207,18 @@ def add_custom_joint(
         raise ValueError("CustomJoint requires at least 1 coordinate")
 
     joint = ET.SubElement(jointset, "CustomJoint", name=name)
-
-    # Parent frame
-    pf = ET.SubElement(joint, "PhysicalOffsetFrame", name=f"{name}_parent")
-    ET.SubElement(pf, "socket_parent").text = f"/bodyset/{parent_body}"
-    ET.SubElement(pf, "translation").text = vec3_str(*location_in_parent)
-    ET.SubElement(pf, "orientation").text = vec3_str(*orientation_in_parent)
-
-    # Child frame
-    cf = ET.SubElement(joint, "PhysicalOffsetFrame", name=f"{name}_child")
-    ET.SubElement(cf, "socket_parent").text = f"/bodyset/{child_body}"
-    ET.SubElement(cf, "translation").text = vec3_str(*location_in_child)
-    ET.SubElement(cf, "orientation").text = vec3_str(*orientation_in_child)
-
-    ET.SubElement(joint, "socket_parent_frame").text = f"{name}_parent"
-    ET.SubElement(joint, "socket_child_frame").text = f"{name}_child"
-
-    # Coordinates
-    coord_set = ET.SubElement(joint, "coordinates")
-    for c in coordinates:
-        coord = ET.SubElement(coord_set, "Coordinate", name=str(c["name"]))
-        ET.SubElement(coord, "default_value").text = f"{float(c['default_value']):.6f}"
-        ET.SubElement(
-            coord, "range"
-        ).text = f"{float(c['range_min']):.6f} {float(c['range_max']):.6f}"
-
-    # SpatialTransform with TransformAxis elements
-    spatial = ET.SubElement(joint, "SpatialTransform")
-    rotation_axes = ["rotation1", "rotation2", "rotation3"]
-    translation_axes = ["translation1", "translation2", "translation3"]
-
-    for i, c in enumerate(coordinates):
-        axis_name = rotation_axes[i] if i < 3 else translation_axes[i - 3]
-        ta = ET.SubElement(spatial, "TransformAxis", name=axis_name)
-        ET.SubElement(ta, "coordinates").text = str(c["name"])
-        ET.SubElement(ta, "axis").text = str(c.get("axis", "0 0 1"))
-
+    _add_joint_frames(
+        joint,
+        name,
+        parent_body,
+        child_body,
+        location_in_parent,
+        location_in_child,
+        orientation_in_parent,
+        orientation_in_child,
+    )
+    _add_coordinate_set(joint, coordinates)
+    _add_spatial_transform(joint, coordinates)
     return joint
 
 

--- a/src/opensim_models/visualization/plots.py
+++ b/src/opensim_models/visualization/plots.py
@@ -36,6 +36,47 @@ _STYLE = {
 }
 
 
+def _validate_trajectory_inputs(
+    time: np.ndarray,
+    positions: dict[str, np.ndarray],
+    joint_names: list[str],
+) -> None:
+    """Raise ValueError if any joint name or array length is invalid."""
+    for name in joint_names:
+        if name not in positions:
+            raise ValueError(f"Joint '{name}' not found in positions dict")
+        if len(positions[name]) != len(time):
+            raise ValueError(
+                f"Joint '{name}' has {len(positions[name])} values "
+                f"but time has {len(time)} values"
+            )
+
+
+def _draw_trajectory_panels(
+    time: np.ndarray,
+    positions: dict[str, np.ndarray],
+    joint_names: list[str],
+    title: str,
+) -> Figure:
+    """Render one subplot per joint and return the Figure."""
+    n_joints = len(joint_names)
+    with plt.rc_context(_STYLE):
+        fig, axes = plt.subplots(n_joints, 1, figsize=(10, 2.5 * n_joints), sharex=True)
+        if n_joints == 1:
+            axes = [axes]
+
+        for ax, name in zip(axes, joint_names, strict=True):
+            angles_deg = np.degrees(positions[name])
+            ax.plot(time, angles_deg, linewidth=1.5, color="#2c7bb6")
+            ax.set_ylabel(f"{name}\n(deg)")
+            ax.legend([name], loc="upper right")
+
+        axes[-1].set_xlabel("Time (s)")
+        fig.suptitle(title, fontsize=14, fontweight="bold")
+        fig.tight_layout()
+    return fig
+
+
 def plot_joint_trajectory(
     time: np.ndarray,
     positions: dict[str, np.ndarray],
@@ -64,34 +105,58 @@ def plot_joint_trajectory(
     if not joint_names:
         raise ValueError("No joints to plot: positions dict is empty")
 
-    for name in joint_names:
-        if name not in positions:
-            raise ValueError(f"Joint '{name}' not found in positions dict")
-        if len(positions[name]) != len(time):
-            raise ValueError(
-                f"Joint '{name}' has {len(positions[name])} values "
-                f"but time has {len(time)} values"
-            )
-
-    n_joints = len(joint_names)
-
-    with plt.rc_context(_STYLE):
-        fig, axes = plt.subplots(n_joints, 1, figsize=(10, 2.5 * n_joints), sharex=True)
-        if n_joints == 1:
-            axes = [axes]
-
-        for ax, name in zip(axes, joint_names, strict=True):
-            angles_deg = np.degrees(positions[name])
-            ax.plot(time, angles_deg, linewidth=1.5, color="#2c7bb6")
-            ax.set_ylabel(f"{name}\n(deg)")
-            ax.legend([name], loc="upper right")
-
-        axes[-1].set_xlabel("Time (s)")
-        fig.suptitle(title, fontsize=14, fontweight="bold")
-        fig.tight_layout()
-
-    logger.info("Created joint trajectory plot with %d panels", n_joints)
+    _validate_trajectory_inputs(time, positions, joint_names)
+    fig = _draw_trajectory_panels(time, positions, joint_names, title)
+    logger.info("Created joint trajectory plot with %d panels", len(joint_names))
     return fig
+
+
+def _collect_phase_coords(objective: ExerciseObjective) -> list[str]:
+    """Return sorted list of all coordinate names used across phases."""
+    all_coords: set[str] = set()
+    for phase in objective.phases:
+        all_coords.update(phase.joint_targets.keys())
+    return sorted(all_coords)
+
+
+def _draw_coord_traces(
+    ax: Any,
+    objective: ExerciseObjective,
+    coord_list: list[str],
+    colors: Any,
+) -> None:
+    """Plot one trajectory line per coordinate on *ax*."""
+    for idx, coord in enumerate(coord_list):
+        t_vals = []
+        angle_vals = []
+        for phase in objective.phases:
+            if coord in phase.joint_targets:
+                t_vals.append(phase.time_fraction)
+                angle_vals.append(np.degrees(phase.joint_targets[coord]))
+        ax.plot(
+            t_vals,
+            angle_vals,
+            marker="o",
+            markersize=8,
+            linewidth=2,
+            color=colors[idx],
+            label=coord,
+        )
+
+
+def _annotate_phase_names(ax: Any, objective: ExerciseObjective) -> None:
+    """Draw vertical phase-boundary lines and rotated phase-name annotations."""
+    for phase in objective.phases:
+        ax.axvline(phase.time_fraction, color="gray", linestyle=":", alpha=0.4)
+        ax.annotate(
+            phase.name,
+            xy=(phase.time_fraction, 1.02),
+            xycoords=cast(Any, ("data", "axes fraction")),
+            ha="center",
+            va="bottom",
+            fontsize=8,
+            rotation=45,
+        )
 
 
 def plot_phase_diagram(
@@ -113,53 +178,17 @@ def plot_phase_diagram(
     if title is None:
         title = f"{objective.name.replace('_', ' ').title()} Phase Diagram"
 
-    # Collect all coordinates that appear across phases
-    all_coords: set[str] = set()
-    for phase in objective.phases:
-        all_coords.update(phase.joint_targets.keys())
-    coord_list = sorted(all_coords)
-
+    coord_list = _collect_phase_coords(objective)
     if not coord_list:
         raise ValueError(f"Exercise '{objective.name}' has no joint targets in phases")
 
-    # Color palette
     cmap = matplotlib.colormaps["Set2"]
     colors = cmap(np.linspace(0, 1, max(len(coord_list), 1)))
 
     with plt.rc_context(_STYLE):
         fig, ax = plt.subplots(figsize=(12, 6))
-
-        for idx, coord in enumerate(coord_list):
-            t_vals = []
-            angle_vals = []
-            for phase in objective.phases:
-                if coord in phase.joint_targets:
-                    t_vals.append(phase.time_fraction)
-                    angle_vals.append(np.degrees(phase.joint_targets[coord]))
-
-            ax.plot(
-                t_vals,
-                angle_vals,
-                marker="o",
-                markersize=8,
-                linewidth=2,
-                color=colors[idx],
-                label=coord,
-            )
-
-        # Annotate phase names along the top
-        for phase in objective.phases:
-            ax.axvline(phase.time_fraction, color="gray", linestyle=":", alpha=0.4)
-            ax.annotate(
-                phase.name,
-                xy=(phase.time_fraction, 1.02),
-                xycoords=cast(Any, ("data", "axes fraction")),
-                ha="center",
-                va="bottom",
-                fontsize=8,
-                rotation=45,
-            )
-
+        _draw_coord_traces(ax, objective, coord_list, colors)
+        _annotate_phase_names(ax, objective)
         ax.set_xlabel("Normalised Time (0-1)")
         ax.set_ylabel("Joint Angle (deg)")
         ax.set_title(title, fontsize=14, fontweight="bold")


### PR DESCRIPTION
Closes #106

## Summary
- Refactored all 13 functions that exceeded the 50-line limit (worst: `_add_upper_limbs()` at 73 lines)
- Extracted focused helper functions from each long method across 8 files
- No behavioral changes — same XML output, same public API

## Files changed
- `body_model.py`: `_add_upper_limbs` → `_add_upper_arm`, `_add_forearm`, `_add_hand`; `_add_lower_limbs` → `_add_thigh`, `_add_shank`, `_add_foot`
- `axial_skeleton.py`: `add_axial_joints` → `_compute_pelvis_height`, `_add_ground_pelvis_joint`, `_add_lumbar_joint`, `_add_neck_joint`
- `xml_helpers.py`: shared `_add_joint_frames`, `_add_coordinate_set`, `_add_spatial_transform` extracted from `add_ball_joint` and `add_custom_joint`
- `limb_builders.py`: `_resolve_parent_name`, `_add_bilateral_body` shared across all three bilateral builders
- `bench_press_model.py`: `_add_bench_and_constraint` → `_add_bench_body`, `_weld_bench_to_ground`, `_weld_pelvis_to_bench_supine`
- `base.py`: `build()` → `_create_model_root`, `_add_gravity_and_ground`, `_build_bodies_and_joints`, `_add_ground_contact`
- `trajectory_optimizer.py`: `interpolate_phases` → `_collect_coords`, `_interpolate_coord`; `create_moco_study` → `_build_solver_dict`, `_build_problem_dict`
- `plots.py`: `plot_joint_trajectory` → `_validate_trajectory_inputs`, `_draw_trajectory_panels`; `plot_phase_diagram` → `_collect_phase_coords`, `_draw_coord_traces`, `_annotate_phase_names`

## Test plan
- [x] All 7 exercises build successfully with identical XML output size
- [x] `ruff check` passes with zero violations
- [x] `ruff format --check` passes with zero diffs
- [x] `mypy src` passes with zero errors
- [x] No functions over 50 lines remain in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)