### PR TITLE
fix: use RUNNER_CHECK_TOKEN for runner detection

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check for self-hosted runner
         id: check
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RUNNER_CHECK_TOKEN }}
         run: |
           ONLINE=$(gh api /orgs/${{ github.repository_owner }}/actions/runners \
             --jq '[.runners[] | select(.status == "online") | select(.labels[].name == "d-sorg-fleet")] | length' \


### PR DESCRIPTION
The pick-runner dispatcher was using secrets.GITHUB_TOKEN to query org runners, which returns 403. Switches to RUNNER_CHECK_TOKEN (a PAT with admin:org scope stored as an org secret).