### PR TITLE
refactor(#123): replace vec6_str scalar params with Vec3 value objects

### DIFF
--- a/src/opensim_models/shared/utils/xml_helpers.py
+++ b/src/opensim_models/shared/utils/xml_helpers.py
@@ -7,8 +7,17 @@ from __future__ import annotations
 
 import logging
 import xml.etree.ElementTree as ET
+from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
+
+
+class Vec3(NamedTuple):
+    """Immutable 3-component vector (x, y, z) for OpenSim XML helpers."""
+
+    x: float
+    y: float
+    z: float
 
 
 def vec3_str(x: float, y: float, z: float) -> str:
@@ -16,9 +25,20 @@ def vec3_str(x: float, y: float, z: float) -> str:
     return f"{x:.6f} {y:.6f} {z:.6f}"
 
 
-def vec6_str(r1: float, r2: float, r3: float, t1: float, t2: float, t3: float) -> str:
-    """Format six floats (rotation + translation) for OpenSim frames."""
-    return f"{r1:.6f} {r2:.6f} {r3:.6f} {t1:.6f} {t2:.6f} {t3:.6f}"
+def vec6_str(rotation: Vec3, translation: Vec3) -> str:
+    """Format a rotation Vec3 and translation Vec3 for OpenSim frames.
+
+    Args:
+        rotation: Euler angles (r1, r2, r3) in radians.
+        translation: Cartesian offsets (t1, t2, t3) in metres.
+
+    Returns:
+        Space-separated string of six floats: ``r1 r2 r3 t1 t2 t3``.
+    """
+    return (
+        f"{rotation.x:.6f} {rotation.y:.6f} {rotation.z:.6f} "
+        f"{translation.x:.6f} {translation.y:.6f} {translation.z:.6f}"
+    )
 
 
 def add_body(

--- a/tests/unit/shared/test_xml_helpers.py
+++ b/tests/unit/shared/test_xml_helpers.py
@@ -5,6 +5,7 @@ import xml.etree.ElementTree as ET
 import pytest
 
 from opensim_models.shared.utils.xml_helpers import (
+    Vec3,
     add_ball_joint,
     add_body,
     add_custom_joint,
@@ -26,9 +27,15 @@ class TestVecFormatters:
         assert "-0.500000" in result
 
     def test_vec6_str(self):
-        result = vec6_str(0, 0, 0, 1, 2, 3)
+        result = vec6_str(Vec3(0, 0, 0), Vec3(1, 2, 3))
         parts = result.split()
         assert len(parts) == 6
+
+    def test_vec6_str_values(self):
+        result = vec6_str(Vec3(0.1, 0.2, 0.3), Vec3(1.0, 2.0, 3.0))
+        assert "0.100000" in result
+        assert "1.000000" in result
+        assert "3.000000" in result
 
 
 class TestAddBody:


### PR DESCRIPTION
## Summary

- Introduces a `Vec3` `NamedTuple` (x, y, z) in `xml_helpers.py` — stdlib only, no new deps
- Changes `vec6_str(r1, r2, r3, t1, t2, t3)` to `vec6_str(rotation: Vec3, translation: Vec3)` so callers pass structured objects instead of six positional floats
- Updates `test_xml_helpers.py` to use the new signature and adds a `test_vec6_str_values` assertion
- No other callers of `vec6_str` exist in `src/`; ruff check and ruff format pass clean

## Test plan

- [ ] `ruff check src tests` — zero violations
- [ ] `ruff format --check src tests` — zero diffs
- [ ] `pytest tests/unit/shared/test_xml_helpers.py` — all vec6_str tests pass
- [ ] `pytest -m "not slow and not requires_opensim"` — full suite green

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)