### PR TITLE
refactor: cleanup DRY, DbC, logging, and XML conventions

### DIFF
--- a/src/opensim_models/exercises/bench_press/bench_press_model.py
+++ b/src/opensim_models/exercises/bench_press/bench_press_model.py
@@ -60,9 +60,6 @@ class BenchPressModelBuilder(ExerciseModelBuilder):
     in a supine (face-up) orientation.
     """
 
-    def __init__(self, config: ExerciseConfig | None = None) -> None:
-        super().__init__(config)
-
     @property
     def exercise_name(self) -> str:
         return "bench_press"

--- a/src/opensim_models/exercises/clean_and_jerk/clean_and_jerk_model.py
+++ b/src/opensim_models/exercises/clean_and_jerk/clean_and_jerk_model.py
@@ -50,9 +50,6 @@ class CleanAndJerkModelBuilder(ExerciseModelBuilder):
     (floor to shoulders) and jerk (shoulders to overhead) phases.
     """
 
-    def __init__(self, config: ExerciseConfig | None = None) -> None:
-        super().__init__(config)
-
     @property
     def exercise_name(self) -> str:
         return "clean_and_jerk"

--- a/src/opensim_models/exercises/deadlift/deadlift_model.py
+++ b/src/opensim_models/exercises/deadlift/deadlift_model.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import logging
 import math
-import warnings
 import xml.etree.ElementTree as ET
 
 from opensim_models.exercises.base import (
@@ -51,9 +50,6 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
     The barbell is welded to both hands and starts on the floor.
     """
 
-    def __init__(self, config: ExerciseConfig | None = None) -> None:
-        super().__init__(config)
-
     @property
     def exercise_name(self) -> str:
         return "deadlift"
@@ -78,11 +74,13 @@ class DeadliftModelBuilder(ExerciseModelBuilder):
         hand_y = torso_top_y - upper_arm - forearm
 
         if abs(hand_y - PLATE_RADIUS) > 0.15:
-            warnings.warn(
-                f"Deadlift initial pose: estimated hand height {hand_y:.3f} m differs from "
-                f"bar height {PLATE_RADIUS:.3f} m by {abs(hand_y - PLATE_RADIUS):.3f} m. "
-                f"Consider adjusting DEADLIFT_INITIAL_* angles.",
-                stacklevel=3,
+            logger.warning(
+                "Deadlift initial pose: estimated hand height %.3f m differs from "
+                "bar height %.3f m by %.3f m. "
+                "Consider adjusting DEADLIFT_INITIAL_* angles.",
+                hand_y,
+                PLATE_RADIUS,
+                abs(hand_y - PLATE_RADIUS),
             )
 
     def attach_barbell(

--- a/src/opensim_models/exercises/gait/gait_model.py
+++ b/src/opensim_models/exercises/gait/gait_model.py
@@ -29,9 +29,6 @@ class GaitModelBuilder(ExerciseModelBuilder):
     with slight hip and knee flexion on the stance leg.
     """
 
-    def __init__(self, config: ExerciseConfig | None = None) -> None:
-        super().__init__(config)
-
     @property
     def exercise_name(self) -> str:
         return "gait"

--- a/src/opensim_models/exercises/snatch/snatch_model.py
+++ b/src/opensim_models/exercises/snatch/snatch_model.py
@@ -43,9 +43,6 @@ logger = logging.getLogger(__name__)
 class SnatchModelBuilder(ExerciseModelBuilder):
     """Builds a snatch OpenSim model with wide grip."""
 
-    def __init__(self, config: ExerciseConfig | None = None) -> None:
-        super().__init__(config)
-
     @property
     def exercise_name(self) -> str:
         return "snatch"

--- a/src/opensim_models/exercises/squat/squat_model.py
+++ b/src/opensim_models/exercises/squat/squat_model.py
@@ -33,9 +33,6 @@ class SquatModelBuilder(ExerciseModelBuilder):
     point would be shifted ~5 cm inferior.
     """
 
-    def __init__(self, config: ExerciseConfig | None = None) -> None:
-        super().__init__(config)
-
     @property
     def exercise_name(self) -> str:
         return "back_squat"

--- a/src/opensim_models/optimization/trajectory_optimizer.py
+++ b/src/opensim_models/optimization/trajectory_optimizer.py
@@ -19,6 +19,10 @@ from opensim_models.optimization.exercise_objectives import (
     ExerciseObjective,
     get_exercise_objective,
 )
+from opensim_models.shared.contracts.preconditions import (
+    require_non_negative,
+    require_positive,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +50,15 @@ class TrajectoryConfig:
     constraint_tolerance: float = 1e-4
     weight_tracking: float = 10.0
     weight_effort: float = 1.0
+
+    def __post_init__(self) -> None:
+        require_positive(self.duration, "duration")
+        require_positive(float(self.num_mesh_points), "num_mesh_points")
+        require_positive(float(self.max_iterations), "max_iterations")
+        require_positive(self.convergence_tolerance, "convergence_tolerance")
+        require_positive(self.constraint_tolerance, "constraint_tolerance")
+        require_non_negative(self.weight_tracking, "weight_tracking")
+        require_non_negative(self.weight_effort, "weight_effort")
 
 
 @dataclass

--- a/src/opensim_models/shared/utils/xml_helpers.py
+++ b/src/opensim_models/shared/utils/xml_helpers.py
@@ -253,20 +253,16 @@ def add_free_joint(
 ) -> ET.Element:
     """Append a <FreeJoint> (6-DOF) to *jointset* and return it."""
     joint = ET.SubElement(jointset, "FreeJoint", name=name)
-
-    pf = ET.SubElement(joint, "PhysicalOffsetFrame", name=f"{name}_parent")
-    ET.SubElement(pf, "socket_parent").text = f"/bodyset/{parent_body}"
-    ET.SubElement(pf, "translation").text = vec3_str(*location_in_parent)
-    ET.SubElement(pf, "orientation").text = vec3_str(0, 0, 0)
-
-    cf = ET.SubElement(joint, "PhysicalOffsetFrame", name=f"{name}_child")
-    ET.SubElement(cf, "socket_parent").text = f"/bodyset/{child_body}"
-    ET.SubElement(cf, "translation").text = vec3_str(*location_in_child)
-    ET.SubElement(cf, "orientation").text = vec3_str(0, 0, 0)
-
-    ET.SubElement(joint, "socket_parent_frame").text = f"{name}_parent"
-    ET.SubElement(joint, "socket_child_frame").text = f"{name}_child"
-
+    _add_joint_frames(
+        joint,
+        name,
+        parent_body,
+        child_body,
+        location_in_parent,
+        location_in_child,
+        (0, 0, 0),
+        (0, 0, 0),
+    )
     return joint
 
 
@@ -281,20 +277,16 @@ def add_weld_joint(
 ) -> ET.Element:
     """Append a <WeldJoint> (rigid attachment) to *jointset*."""
     joint = ET.SubElement(jointset, "WeldJoint", name=name)
-
-    pf = ET.SubElement(joint, "PhysicalOffsetFrame", name=f"{name}_parent")
-    ET.SubElement(pf, "socket_parent").text = f"/bodyset/{parent_body}"
-    ET.SubElement(pf, "translation").text = vec3_str(*location_in_parent)
-    ET.SubElement(pf, "orientation").text = vec3_str(0, 0, 0)
-
-    cf = ET.SubElement(joint, "PhysicalOffsetFrame", name=f"{name}_child")
-    ET.SubElement(cf, "socket_parent").text = f"/bodyset/{child_body}"
-    ET.SubElement(cf, "translation").text = vec3_str(*location_in_child)
-    ET.SubElement(cf, "orientation").text = vec3_str(0, 0, 0)
-
-    ET.SubElement(joint, "socket_parent_frame").text = f"{name}_parent"
-    ET.SubElement(joint, "socket_child_frame").text = f"{name}_child"
-
+    _add_joint_frames(
+        joint,
+        name,
+        parent_body,
+        child_body,
+        location_in_parent,
+        location_in_child,
+        (0, 0, 0),
+        (0, 0, 0),
+    )
     return joint
 
 
@@ -316,26 +308,7 @@ def set_coordinate_default(jointset: ET.Element, coord_name: str, value: float) 
     raise ValueError(f"Coordinate {coord_name!r} not found in jointset")
 
 
-def indent_xml(elem: ET.Element, level: int = 0) -> None:
-    """Add whitespace indentation to an ElementTree in-place."""
-    indent = "\n" + "  " * level
-    if len(elem):
-        if not elem.text or not elem.text.strip():
-            elem.text = indent + "  "
-        if not elem.tail or not elem.tail.strip():
-            elem.tail = indent
-        for child in elem:
-            indent_xml(child, level + 1)
-        if not child.tail or not child.tail.strip():
-            child.tail = indent
-    else:
-        if level and (not elem.tail or not elem.tail.strip()):
-            elem.tail = indent
-    if level == 0:
-        elem.tail = "\n"
-
-
 def serialize_model(root: ET.Element) -> str:
     """Serialize an OpenSim model ElementTree to a formatted XML string."""
-    indent_xml(root)
+    ET.indent(root, space="  ")
     return ET.tostring(root, encoding="unicode", xml_declaration=True)


### PR DESCRIPTION
## Summary
- Remove redundant pass-through `__init__` from 6 exercise subclasses (#134)
- Replace `warnings.warn()` with `logger.warning()` in deadlift_model.py (#133)
- Replace manual `indent_xml` with stdlib `ET.indent()` (#132)
- Use `_add_joint_frames` helper in `add_free_joint` and `add_weld_joint` (#131)
- Add `TrajectoryConfig.__post_init__` DbC validation (#129)

Closes #129, #131, #132, #133, #134

## Test plan
- [x] 426 tests pass
- [x] ruff check: zero violations
- [x] ruff format: no diffs
- [x] mypy: pre-existing `plots.py` error only (unchanged from main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)