### PR TITLE
Refactor free and weld joint frame setup

### DIFF
--- a/src/opensim_models/shared/utils/xml_helpers.py
+++ b/src/opensim_models/shared/utils/xml_helpers.py
@@ -11,6 +11,8 @@ from typing import NamedTuple
 
 logger = logging.getLogger(__name__)
 
+ZERO_VEC3: tuple[float, float, float] = (0.0, 0.0, 0.0)
+
 
 class Vec3(NamedTuple):
     """Immutable 3-component vector (x, y, z) for OpenSim XML helpers."""
@@ -260,8 +262,8 @@ def add_free_joint(
         child_body,
         location_in_parent,
         location_in_child,
-        (0, 0, 0),
-        (0, 0, 0),
+        ZERO_VEC3,
+        ZERO_VEC3,
     )
     return joint
 
@@ -284,8 +286,8 @@ def add_weld_joint(
         child_body,
         location_in_parent,
         location_in_child,
-        (0, 0, 0),
-        (0, 0, 0),
+        ZERO_VEC3,
+        ZERO_VEC3,
     )
     return joint
 

--- a/tests/unit/shared/test_xml_helpers.py
+++ b/tests/unit/shared/test_xml_helpers.py
@@ -114,6 +114,25 @@ class TestAddFreeJoint:
         )
         assert joint.tag == "FreeJoint"
 
+    def test_uses_shared_joint_frames(self):
+        jointset = ET.Element("JointSet")
+        joint = add_free_joint(
+            jointset,
+            name="ground_pelvis",
+            parent_body="ground",
+            child_body="pelvis",
+            location_in_parent=(1, 2, 3),
+            location_in_child=(4, 5, 6),
+        )
+        parent_frame = joint.find("PhysicalOffsetFrame[@name='ground_pelvis_parent']")
+        child_frame = joint.find("PhysicalOffsetFrame[@name='ground_pelvis_child']")
+        assert parent_frame is not None
+        assert child_frame is not None
+        assert parent_frame.findtext("socket_parent") == "/bodyset/ground"
+        assert child_frame.findtext("socket_parent") == "/bodyset/pelvis"
+        assert parent_frame.findtext("orientation") == "0.000000 0.000000 0.000000"
+        assert child_frame.findtext("orientation") == "0.000000 0.000000 0.000000"
+
 
 class TestAddWeldJoint:
     def test_creates_weld_joint(self):
@@ -126,6 +145,24 @@ class TestAddWeldJoint:
             location_in_parent=(0, 1, 0),
         )
         assert joint.tag == "WeldJoint"
+
+    def test_uses_shared_joint_frames(self):
+        jointset = ET.Element("JointSet")
+        joint = add_weld_joint(
+            jointset,
+            name="weld",
+            parent_body="a",
+            child_body="b",
+            location_in_parent=(7, 8, 9),
+        )
+        parent_frame = joint.find("PhysicalOffsetFrame[@name='weld_parent']")
+        child_frame = joint.find("PhysicalOffsetFrame[@name='weld_child']")
+        assert parent_frame is not None
+        assert child_frame is not None
+        assert parent_frame.findtext("socket_parent") == "/bodyset/a"
+        assert child_frame.findtext("socket_parent") == "/bodyset/b"
+        assert parent_frame.findtext("orientation") == "0.000000 0.000000 0.000000"
+        assert child_frame.findtext("orientation") == "0.000000 0.000000 0.000000"
 
 
 class TestIndentXml:


### PR DESCRIPTION
This keeps the fixed joints aligned with the shared frame-building path and adds regression coverage for the generated parent/child frames.

Validation:
- pytest tests/unit/shared/test_xml_helpers.py
- ruff check src/opensim_models/shared/utils/xml_helpers.py tests/unit/shared/test_xml_helpers.py

Closes #131