### PR TITLE
Add dedicated tests for trajectory optimizer and limb builders

### DIFF
--- a/tests/unit/test_limb_builders.py
+++ b/tests/unit/test_limb_builders.py
@@ -46,12 +46,34 @@ class TestAddBilateralLimb:
         assert left_joint is not None
         assert right_joint is not None
         assert left_joint.find("PhysicalOffsetFrame[@name='knee_l_parent']") is not None
-        assert right_joint.find("PhysicalOffsetFrame[@name='knee_r_parent']") is not None
+        assert (
+            right_joint.find("PhysicalOffsetFrame[@name='knee_r_parent']") is not None
+        )
 
-        assert left_joint.find("PhysicalOffsetFrame[@name='knee_l_parent']/socket_parent").text == "/bodyset/thigh_l"  # type: ignore[union-attr]
-        assert right_joint.find("PhysicalOffsetFrame[@name='knee_r_parent']/socket_parent").text == "/bodyset/thigh_r"  # type: ignore[union-attr]
-        assert left_joint.find("PhysicalOffsetFrame[@name='knee_l_parent']/translation").text == "-0.080000 -0.420000 0.000000"  # type: ignore[union-attr]
-        assert right_joint.find("PhysicalOffsetFrame[@name='knee_r_parent']/translation").text == "0.080000 -0.420000 0.000000"  # type: ignore[union-attr]
+        assert (
+            left_joint.find(
+                "PhysicalOffsetFrame[@name='knee_l_parent']/socket_parent"
+            ).text
+            == "/bodyset/thigh_l"
+        )  # type: ignore[union-attr]
+        assert (
+            right_joint.find(
+                "PhysicalOffsetFrame[@name='knee_r_parent']/socket_parent"
+            ).text
+            == "/bodyset/thigh_r"
+        )  # type: ignore[union-attr]
+        assert (
+            left_joint.find(
+                "PhysicalOffsetFrame[@name='knee_l_parent']/translation"
+            ).text
+            == "-0.080000 -0.420000 0.000000"
+        )  # type: ignore[union-attr]
+        assert (
+            right_joint.find(
+                "PhysicalOffsetFrame[@name='knee_r_parent']/translation"
+            ).text
+            == "0.080000 -0.420000 0.000000"
+        )  # type: ignore[union-attr]
         assert left_joint.find(".//Coordinate").get("name") == "knee_l_flex"  # type: ignore[union-attr]
         assert right_joint.find(".//Coordinate").get("name") == "knee_r_flex"  # type: ignore[union-attr]
 
@@ -84,8 +106,18 @@ class TestAddBilateralBallJointLimb:
         for side, sign in [("l", -1.0), ("r", 1.0)]:
             joint = jointset.find(f"BallJoint[@name='shoulder_{side}']")
             assert joint is not None
-            assert joint.find(f"PhysicalOffsetFrame[@name='shoulder_{side}_parent']/socket_parent").text == "/bodyset/torso"  # type: ignore[union-attr]
-            assert joint.find(f"PhysicalOffsetFrame[@name='shoulder_{side}_parent']/translation").text == f"{sign * 0.110000:.6f} 0.330000 0.000000"  # type: ignore[union-attr]
+            assert (
+                joint.find(
+                    f"PhysicalOffsetFrame[@name='shoulder_{side}_parent']/socket_parent"
+                ).text
+                == "/bodyset/torso"
+            )  # type: ignore[union-attr]
+            assert (
+                joint.find(
+                    f"PhysicalOffsetFrame[@name='shoulder_{side}_parent']/translation"
+                ).text
+                == f"{sign * 0.110000:.6f} 0.330000 0.000000"
+            )  # type: ignore[union-attr]
 
             coords = joint.findall(".//Coordinate")
             assert [c.get("name") for c in coords] == [
@@ -136,7 +168,12 @@ class TestAddBilateralCustomJointLimb:
         for side in ("l", "r"):
             joint = jointset.find(f"CustomJoint[@name='ankle_{side}']")
             assert joint is not None
-            assert joint.find(f"PhysicalOffsetFrame[@name='ankle_{side}_parent']/socket_parent").text == f"/bodyset/shank_{side}"  # type: ignore[union-attr]
+            assert (
+                joint.find(
+                    f"PhysicalOffsetFrame[@name='ankle_{side}_parent']/socket_parent"
+                ).text
+                == f"/bodyset/shank_{side}"
+            )  # type: ignore[union-attr]
 
             coords = joint.findall(".//Coordinate")
             assert [c.get("name") for c in coords] == [
@@ -148,5 +185,8 @@ class TestAddBilateralCustomJointLimb:
             assert coords[1].find("default_value").text == "0.000000"  # type: ignore[union-attr]
             assert coords[1].find("range").text == "-0.300000 0.300000"  # type: ignore[union-attr]
 
-            axes = [axis.find("axis").text for axis in joint.findall("SpatialTransform/TransformAxis")]  # type: ignore[union-attr]
+            axes = [
+                axis.find("axis").text
+                for axis in joint.findall("SpatialTransform/TransformAxis")
+            ]  # type: ignore[union-attr]
             assert axes == ["0 0 1", "0 0 1"]

--- a/tests/unit/test_limb_builders.py
+++ b/tests/unit/test_limb_builders.py
@@ -1,0 +1,152 @@
+"""Dedicated tests for bilateral limb builder helpers."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from opensim_models.shared.body._segment_data import BodyModelSpec
+from opensim_models.shared.body.limb_builders import (
+    add_bilateral_ball_joint_limb,
+    add_bilateral_custom_joint_limb,
+    add_bilateral_limb,
+)
+
+
+class TestAddBilateralLimb:
+    """Pin-joint builder should create symmetric left/right limbs."""
+
+    def test_creates_side_specific_bodies_and_joints(self) -> None:
+        bodyset = ET.Element("BodySet")
+        jointset = ET.Element("JointSet")
+        bodies: dict[str, ET.Element] = {}
+        spec = BodyModelSpec(total_mass=80.0, height=1.75)
+
+        add_bilateral_limb(
+            bodyset,
+            jointset,
+            spec,
+            seg_name="shank",
+            parent_name="thigh",
+            parent_offset_y=-0.42,
+            parent_lateral_x=0.08,
+            coord_prefix="knee",
+            range_min=-2.5,
+            range_max=0.1,
+            bodies=bodies,
+        )
+
+        assert set(bodies) == {"shank_l", "shank_r"}
+        assert {body.get("name") for body in bodyset.findall("Body")} == {
+            "shank_l",
+            "shank_r",
+        }
+
+        left_joint = jointset.find("PinJoint[@name='knee_l']")
+        right_joint = jointset.find("PinJoint[@name='knee_r']")
+        assert left_joint is not None
+        assert right_joint is not None
+        assert left_joint.find("PhysicalOffsetFrame[@name='knee_l_parent']") is not None
+        assert right_joint.find("PhysicalOffsetFrame[@name='knee_r_parent']") is not None
+
+        assert left_joint.find("PhysicalOffsetFrame[@name='knee_l_parent']/socket_parent").text == "/bodyset/thigh_l"  # type: ignore[union-attr]
+        assert right_joint.find("PhysicalOffsetFrame[@name='knee_r_parent']/socket_parent").text == "/bodyset/thigh_r"  # type: ignore[union-attr]
+        assert left_joint.find("PhysicalOffsetFrame[@name='knee_l_parent']/translation").text == "-0.080000 -0.420000 0.000000"  # type: ignore[union-attr]
+        assert right_joint.find("PhysicalOffsetFrame[@name='knee_r_parent']/translation").text == "0.080000 -0.420000 0.000000"  # type: ignore[union-attr]
+        assert left_joint.find(".//Coordinate").get("name") == "knee_l_flex"  # type: ignore[union-attr]
+        assert right_joint.find(".//Coordinate").get("name") == "knee_r_flex"  # type: ignore[union-attr]
+
+
+class TestAddBilateralBallJointLimb:
+    """Ball-joint builder should emit three coordinates per side."""
+
+    def test_creates_three_coordinate_ball_joints(self) -> None:
+        bodyset = ET.Element("BodySet")
+        jointset = ET.Element("JointSet")
+        spec = BodyModelSpec(total_mass=75.0, height=1.80)
+
+        add_bilateral_ball_joint_limb(
+            bodyset,
+            jointset,
+            spec,
+            seg_name="upper_arm",
+            parent_name="torso",
+            parent_offset_y=0.33,
+            parent_lateral_x=0.11,
+            coord_prefix="shoulder",
+            coord_suffixes=("flex", "adduct", "rotate"),
+            ranges=(
+                (-1.0, 2.0),
+                (-0.5, 0.5),
+                (-0.75, 0.75),
+            ),
+        )
+
+        for side, sign in [("l", -1.0), ("r", 1.0)]:
+            joint = jointset.find(f"BallJoint[@name='shoulder_{side}']")
+            assert joint is not None
+            assert joint.find(f"PhysicalOffsetFrame[@name='shoulder_{side}_parent']/socket_parent").text == "/bodyset/torso"  # type: ignore[union-attr]
+            assert joint.find(f"PhysicalOffsetFrame[@name='shoulder_{side}_parent']/translation").text == f"{sign * 0.110000:.6f} 0.330000 0.000000"  # type: ignore[union-attr]
+
+            coords = joint.findall(".//Coordinate")
+            assert [c.get("name") for c in coords] == [
+                f"shoulder_{side}_flex",
+                f"shoulder_{side}_adduct",
+                f"shoulder_{side}_rotate",
+            ]
+            assert [c.find("range").text for c in coords] == [  # type: ignore[union-attr]
+                "-1.000000 2.000000",
+                "-0.500000 0.500000",
+                "-0.750000 0.750000",
+            ]
+
+
+class TestAddBilateralCustomJointLimb:
+    """Custom-joint builder should preserve per-axis metadata."""
+
+    def test_creates_custom_joint_coordinates_and_axes(self) -> None:
+        bodyset = ET.Element("BodySet")
+        jointset = ET.Element("JointSet")
+        spec = BodyModelSpec(total_mass=68.0, height=1.72)
+
+        add_bilateral_custom_joint_limb(
+            bodyset,
+            jointset,
+            spec,
+            seg_name="foot",
+            parent_name="shank",
+            parent_offset_y=-0.39,
+            parent_lateral_x=0.0,
+            coord_prefix="ankle",
+            coord_defs=[
+                {
+                    "suffix": "flex",
+                    "default_value": 0.1,
+                    "range_min": -0.2,
+                    "range_max": 0.8,
+                    "axis": "0 0 1",
+                },
+                {
+                    "suffix": "inversion",
+                    "range_min": -0.3,
+                    "range_max": 0.3,
+                },
+            ],
+        )
+
+        for side in ("l", "r"):
+            joint = jointset.find(f"CustomJoint[@name='ankle_{side}']")
+            assert joint is not None
+            assert joint.find(f"PhysicalOffsetFrame[@name='ankle_{side}_parent']/socket_parent").text == f"/bodyset/shank_{side}"  # type: ignore[union-attr]
+
+            coords = joint.findall(".//Coordinate")
+            assert [c.get("name") for c in coords] == [
+                f"ankle_{side}_flex",
+                f"ankle_{side}_inversion",
+            ]
+            assert coords[0].find("default_value").text == "0.100000"  # type: ignore[union-attr]
+            assert coords[0].find("range").text == "-0.200000 0.800000"  # type: ignore[union-attr]
+            assert coords[1].find("default_value").text == "0.000000"  # type: ignore[union-attr]
+            assert coords[1].find("range").text == "-0.300000 0.300000"  # type: ignore[union-attr]
+
+            axes = [axis.find("axis").text for axis in joint.findall("SpatialTransform/TransformAxis")]  # type: ignore[union-attr]
+            assert axes == ["0 0 1", "0 0 1"]

--- a/tests/unit/test_trajectory_optimizer.py
+++ b/tests/unit/test_trajectory_optimizer.py
@@ -1,0 +1,146 @@
+"""Dedicated tests for trajectory optimization helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from opensim_models.optimization._types import ExerciseObjective, Phase
+from opensim_models.optimization.trajectory_optimizer import (
+    TrajectoryConfig,
+    create_moco_study,
+    interpolate_phases,
+)
+
+
+class TestTrajectoryConfigValidation:
+    """TrajectoryConfig should enforce its contract at construction time."""
+
+    @pytest.mark.parametrize(
+        ("field_name", "value", "match"),
+        [
+            ("duration", 0.0, "duration"),
+            ("num_mesh_points", 0, "num_mesh_points"),
+            ("max_iterations", 0, "max_iterations"),
+            ("convergence_tolerance", 0.0, "convergence_tolerance"),
+            ("constraint_tolerance", 0.0, "constraint_tolerance"),
+            ("weight_tracking", -1.0, "weight_tracking"),
+            ("weight_effort", -0.1, "weight_effort"),
+        ],
+    )
+    def test_rejects_invalid_values(
+        self, field_name: str, value: float | int, match: str
+    ) -> None:
+        kwargs = {field_name: value}
+        with pytest.raises(ValueError, match=match):
+            TrajectoryConfig(**kwargs)
+
+    def test_accepts_valid_custom_values(self) -> None:
+        cfg = TrajectoryConfig(
+            exercise_name="bench_press",
+            duration=4.5,
+            num_mesh_points=75,
+            max_iterations=250,
+            convergence_tolerance=1e-5,
+            constraint_tolerance=2e-5,
+            weight_tracking=12.0,
+            weight_effort=0.25,
+        )
+
+        assert cfg.exercise_name == "bench_press"
+        assert cfg.duration == 4.5
+        assert cfg.num_mesh_points == 75
+        assert cfg.max_iterations == 250
+        assert cfg.convergence_tolerance == 1e-5
+        assert cfg.constraint_tolerance == 2e-5
+        assert cfg.weight_tracking == 12.0
+        assert cfg.weight_effort == 0.25
+
+
+class TestInterpolatePhases:
+    """Interpolation should preserve phase endpoints and fill sparse targets."""
+
+    def test_interpolates_sparse_coordinate_as_constant(self) -> None:
+        objective = ExerciseObjective(
+            name="custom",
+            phases=(
+                Phase(
+                    name="start",
+                    time_fraction=0.0,
+                    joint_targets={"hip_flexion": 1.0, "knee_flexion": 0.2},
+                ),
+                Phase(
+                    name="finish",
+                    time_fraction=1.0,
+                    joint_targets={"knee_flexion": 0.8},
+                ),
+            ),
+        )
+
+        result = interpolate_phases(objective, num_points=5, duration=2.0)
+
+        np.testing.assert_allclose(result.time, np.linspace(0.0, 2.0, 5))
+        np.testing.assert_allclose(result.coordinates["hip_flexion"], 1.0)
+        np.testing.assert_allclose(
+            result.coordinates["knee_flexion"],
+            np.linspace(0.2, 0.8, 5),
+        )
+
+    @pytest.mark.parametrize(
+        ("num_points", "duration", "match"),
+        [
+            (1, 1.0, "num_points"),
+            (4, 0.0, "duration"),
+        ],
+    )
+    def test_rejects_invalid_sampling_arguments(
+        self, num_points: int, duration: float, match: str
+    ) -> None:
+        objective = ExerciseObjective(
+            name="custom",
+            phases=(
+                Phase(name="start", time_fraction=0.0),
+                Phase(name="end", time_fraction=1.0),
+            ),
+        )
+
+        with pytest.raises(ValueError, match=match):
+            interpolate_phases(objective, num_points=num_points, duration=duration)
+
+
+class TestCreateMocoStudy:
+    """The Moco study dict should reflect the supplied configuration."""
+
+    def test_builds_solver_problem_and_initial_guess(self) -> None:
+        cfg = TrajectoryConfig(
+            exercise_name="squat",
+            duration=2.5,
+            num_mesh_points=12,
+            max_iterations=222,
+            convergence_tolerance=3e-5,
+            constraint_tolerance=4e-5,
+            weight_tracking=8.0,
+            weight_effort=1.5,
+        )
+
+        study = create_moco_study(cfg)
+
+        assert study["solver"] == {
+            "type": "MocoCasADiSolver",
+            "max_iterations": 222,
+            "convergence_tolerance": 3e-5,
+            "constraint_tolerance": 4e-5,
+            "num_mesh_intervals": 12,
+        }
+        assert study["problem"]["exercise"] == "squat"
+        assert study["problem"]["duration"] == 2.5
+        assert study["problem"]["cost_weights"] == {
+            "tracking": 8.0,
+            "effort": 1.5,
+        }
+        assert len(study["initial_guess"]["time"]) == 12
+        assert len(study["initial_guess"]["coordinates"]) > 0
+        assert list(study["problem"]["coordinates"]) == list(
+            study["initial_guess"]["coordinates"].keys()
+        )
+

--- a/tests/unit/test_trajectory_optimizer.py
+++ b/tests/unit/test_trajectory_optimizer.py
@@ -143,4 +143,3 @@ class TestCreateMocoStudy:
         assert list(study["problem"]["coordinates"]) == list(
             study["initial_guess"]["coordinates"].keys()
         )
-


### PR DESCRIPTION
Adds focused unit coverage for the two modules called out in #130.\n\n- Validates TrajectoryConfig contract and Moco study construction\n- Exercises sparse interpolation behavior\n- Verifies bilateral limb builders create the expected bodies, joints, coordinates, and parent resolution\n\nCloses #130