### PR TITLE
test: expand trajectory_optimizer and limb_builders coverage (#130)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -126,5 +126,6 @@ CLI or by direct builder calls and are not treated as maintained source files.
 
 | Date | Version | Notes |
 | --- | --- | --- |
+| 2026-04-11 | 1.0.2 | Expanded `tests/unit/test_trajectory_optimizer.py` and `tests/unit/test_limb_builders.py` with additional happy-path, edge-case, and DbC coverage for every public entry point (issue #130). |
 | 2026-04-09 | 1.0.1 | Replaced handwritten XML indentation with `xml.etree.ElementTree.indent`, standardized deadlift feasibility warnings on repo logging, and removed redundant builder constructors while preserving constructor coverage in tests. |
 | 2026-04-05 | 1.0.0 | Initial root specification for the maintained OpenSim_Models package and CLI surface. |

--- a/tests/unit/test_limb_builders.py
+++ b/tests/unit/test_limb_builders.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import xml.etree.ElementTree as ET
 
+import pytest
+
 from opensim_models.shared.body._segment_data import BodyModelSpec
 from opensim_models.shared.body.limb_builders import (
     add_bilateral_ball_joint_limb,
@@ -77,6 +79,57 @@ class TestAddBilateralLimb:
         assert left_joint.find(".//Coordinate").get("name") == "knee_l_flex"  # type: ignore[union-attr]
         assert right_joint.find(".//Coordinate").get("name") == "knee_r_flex"  # type: ignore[union-attr]
 
+    def test_bodies_dict_is_optional(self) -> None:
+        """When ``bodies=None`` the builder still writes to bodyset/jointset."""
+        bodyset = ET.Element("BodySet")
+        jointset = ET.Element("JointSet")
+        spec = BodyModelSpec(total_mass=80.0, height=1.75)
+
+        add_bilateral_limb(
+            bodyset,
+            jointset,
+            spec,
+            seg_name="shank",
+            parent_name="thigh",
+            parent_offset_y=-0.42,
+            parent_lateral_x=0.08,
+            coord_prefix="knee",
+            range_min=-2.5,
+            range_max=0.1,
+            bodies=None,
+        )
+
+        assert len(bodyset.findall("Body")) == 2
+        assert len(jointset.findall("PinJoint")) == 2
+
+    def test_coordinate_range_values_match_inputs(self) -> None:
+        """Happy path: the pin joint's coordinate range must mirror inputs."""
+        bodyset = ET.Element("BodySet")
+        jointset = ET.Element("JointSet")
+        spec = BodyModelSpec(total_mass=80.0, height=1.75)
+
+        add_bilateral_limb(
+            bodyset,
+            jointset,
+            spec,
+            seg_name="shank",
+            parent_name="thigh",
+            parent_offset_y=-0.42,
+            parent_lateral_x=0.08,
+            coord_prefix="knee",
+            range_min=-2.5,
+            range_max=0.1,
+        )
+
+        for side in ("l", "r"):
+            joint = jointset.find(f"PinJoint[@name='knee_{side}']")
+            assert joint is not None
+            range_el = joint.find(".//Coordinate/range")
+            assert range_el is not None
+            lo, hi = (float(x) for x in range_el.text.split())  # type: ignore[union-attr]
+            assert lo == pytest.approx(-2.5)
+            assert hi == pytest.approx(0.1)
+
 
 class TestAddBilateralBallJointLimb:
     """Ball-joint builder should emit three coordinates per side."""
@@ -130,6 +183,56 @@ class TestAddBilateralBallJointLimb:
                 "-0.500000 0.500000",
                 "-0.750000 0.750000",
             ]
+
+    def test_registers_bodies_in_provided_dict(self) -> None:
+        """If a bodies dict is supplied, both sides should appear in it."""
+        bodyset = ET.Element("BodySet")
+        jointset = ET.Element("JointSet")
+        bodies: dict[str, ET.Element] = {}
+        spec = BodyModelSpec(total_mass=75.0, height=1.80)
+
+        add_bilateral_ball_joint_limb(
+            bodyset,
+            jointset,
+            spec,
+            seg_name="upper_arm",
+            parent_name="torso",
+            parent_offset_y=0.33,
+            parent_lateral_x=0.11,
+            coord_prefix="shoulder",
+            coord_suffixes=("flex", "adduct", "rotate"),
+            ranges=(
+                (-1.0, 2.0),
+                (-0.5, 0.5),
+                (-0.75, 0.75),
+            ),
+            bodies=bodies,
+        )
+
+        assert set(bodies) == {"upper_arm_l", "upper_arm_r"}
+
+    def test_mismatched_suffixes_and_ranges_raise(self) -> None:
+        """``zip(..., strict=True)`` should reject length mismatches."""
+        bodyset = ET.Element("BodySet")
+        jointset = ET.Element("JointSet")
+        spec = BodyModelSpec(total_mass=75.0, height=1.80)
+
+        with pytest.raises(ValueError):
+            add_bilateral_ball_joint_limb(
+                bodyset,
+                jointset,
+                spec,
+                seg_name="upper_arm",
+                parent_name="torso",
+                parent_offset_y=0.33,
+                parent_lateral_x=0.11,
+                coord_prefix="shoulder",
+                coord_suffixes=("flex", "adduct", "rotate"),
+                ranges=(  # type: ignore[arg-type]
+                    (-1.0, 2.0),
+                    (-0.5, 0.5),
+                ),
+            )
 
 
 class TestAddBilateralCustomJointLimb:
@@ -190,3 +293,57 @@ class TestAddBilateralCustomJointLimb:
                 for axis in joint.findall("SpatialTransform/TransformAxis")
             ]  # type: ignore[union-attr]
             assert axes == ["0 0 1", "0 0 1"]
+
+    def test_missing_required_range_key_raises(self) -> None:
+        """DbC: a coord_def without ``range_min`` should raise KeyError."""
+        bodyset = ET.Element("BodySet")
+        jointset = ET.Element("JointSet")
+        spec = BodyModelSpec(total_mass=68.0, height=1.72)
+
+        with pytest.raises(KeyError):
+            add_bilateral_custom_joint_limb(
+                bodyset,
+                jointset,
+                spec,
+                seg_name="foot",
+                parent_name="shank",
+                parent_offset_y=-0.39,
+                parent_lateral_x=0.0,
+                coord_prefix="ankle",
+                coord_defs=[
+                    {"suffix": "flex", "range_max": 0.8},
+                ],
+            )
+
+    def test_bilateral_parent_resolution_for_shank(self) -> None:
+        """Children of bilateral parents should resolve to side-qualified names."""
+        bodyset = ET.Element("BodySet")
+        jointset = ET.Element("JointSet")
+        spec = BodyModelSpec(total_mass=68.0, height=1.72)
+
+        add_bilateral_custom_joint_limb(
+            bodyset,
+            jointset,
+            spec,
+            seg_name="foot",
+            parent_name="shank",
+            parent_offset_y=-0.39,
+            parent_lateral_x=0.0,
+            coord_prefix="ankle",
+            coord_defs=[
+                {
+                    "suffix": "flex",
+                    "range_min": -0.3,
+                    "range_max": 0.3,
+                },
+            ],
+        )
+
+        for side in ("l", "r"):
+            joint = jointset.find(f"CustomJoint[@name='ankle_{side}']")
+            assert joint is not None
+            socket = joint.find(
+                f"PhysicalOffsetFrame[@name='ankle_{side}_parent']/socket_parent"
+            )
+            assert socket is not None
+            assert socket.text == f"/bodyset/shank_{side}"

--- a/tests/unit/test_trajectory_optimizer.py
+++ b/tests/unit/test_trajectory_optimizer.py
@@ -8,6 +8,7 @@ import pytest
 from opensim_models.optimization._types import ExerciseObjective, Phase
 from opensim_models.optimization.trajectory_optimizer import (
     TrajectoryConfig,
+    TrajectoryResult,
     create_moco_study,
     interpolate_phases,
 )
@@ -48,13 +49,33 @@ class TestTrajectoryConfigValidation:
         )
 
         assert cfg.exercise_name == "bench_press"
-        assert cfg.duration == 4.5
+        assert cfg.duration == pytest.approx(4.5)
         assert cfg.num_mesh_points == 75
         assert cfg.max_iterations == 250
-        assert cfg.convergence_tolerance == 1e-5
-        assert cfg.constraint_tolerance == 2e-5
-        assert cfg.weight_tracking == 12.0
-        assert cfg.weight_effort == 0.25
+        assert cfg.convergence_tolerance == pytest.approx(1e-5)
+        assert cfg.constraint_tolerance == pytest.approx(2e-5)
+        assert cfg.weight_tracking == pytest.approx(12.0)
+        assert cfg.weight_effort == pytest.approx(0.25)
+
+    def test_defaults_are_valid(self) -> None:
+        """Default construction should succeed and produce expected defaults."""
+        cfg = TrajectoryConfig()
+
+        assert cfg.exercise_name == "squat"
+        assert cfg.duration == pytest.approx(3.0)
+        assert cfg.num_mesh_points == 50
+        assert cfg.max_iterations == 1000
+        assert cfg.convergence_tolerance == pytest.approx(1e-4)
+        assert cfg.constraint_tolerance == pytest.approx(1e-4)
+        assert cfg.weight_tracking == pytest.approx(10.0)
+        assert cfg.weight_effort == pytest.approx(1.0)
+
+    def test_zero_weights_are_allowed(self) -> None:
+        """Non-negative weights permit zero (disabling a cost term)."""
+        cfg = TrajectoryConfig(weight_tracking=0.0, weight_effort=0.0)
+
+        assert cfg.weight_tracking == pytest.approx(0.0)
+        assert cfg.weight_effort == pytest.approx(0.0)
 
 
 class TestInterpolatePhases:
@@ -90,7 +111,10 @@ class TestInterpolatePhases:
         ("num_points", "duration", "match"),
         [
             (1, 1.0, "num_points"),
+            (0, 1.0, "num_points"),
+            (-3, 1.0, "num_points"),
             (4, 0.0, "duration"),
+            (4, -0.5, "duration"),
         ],
     )
     def test_rejects_invalid_sampling_arguments(
@@ -106,6 +130,85 @@ class TestInterpolatePhases:
 
         with pytest.raises(ValueError, match=match):
             interpolate_phases(objective, num_points=num_points, duration=duration)
+
+    def test_minimum_two_points_preserves_endpoints(self) -> None:
+        """Boundary: num_points=2 should return exact start and end values."""
+        objective = ExerciseObjective(
+            name="custom",
+            phases=(
+                Phase(
+                    name="start",
+                    time_fraction=0.0,
+                    joint_targets={"hip_flexion": 0.0},
+                ),
+                Phase(
+                    name="end",
+                    time_fraction=1.0,
+                    joint_targets={"hip_flexion": 1.5},
+                ),
+            ),
+        )
+
+        result = interpolate_phases(objective, num_points=2, duration=1.0)
+
+        assert result.time.shape == (2,)
+        assert result.coordinates["hip_flexion"][0] == pytest.approx(0.0)
+        assert result.coordinates["hip_flexion"][1] == pytest.approx(1.5)
+
+    def test_intermediate_phase_is_hit_exactly(self) -> None:
+        """A phase at t=0.5 with odd num_points must be sampled exactly."""
+        objective = ExerciseObjective(
+            name="custom",
+            phases=(
+                Phase(
+                    name="start",
+                    time_fraction=0.0,
+                    joint_targets={"knee_flexion": 0.0},
+                ),
+                Phase(
+                    name="mid",
+                    time_fraction=0.5,
+                    joint_targets={"knee_flexion": 2.0},
+                ),
+                Phase(
+                    name="end",
+                    time_fraction=1.0,
+                    joint_targets={"knee_flexion": 0.0},
+                ),
+            ),
+        )
+
+        result = interpolate_phases(objective, num_points=5, duration=2.0)
+
+        # Midpoint index == 2 for 5 evenly spaced samples.
+        assert result.coordinates["knee_flexion"][2] == pytest.approx(2.0)
+        assert result.coordinates["knee_flexion"][0] == pytest.approx(0.0)
+        assert result.coordinates["knee_flexion"][-1] == pytest.approx(0.0)
+
+    def test_result_reports_trivial_convergence(self) -> None:
+        """Interpolated trajectories are tagged as converged with zero objective."""
+        objective = ExerciseObjective(
+            name="custom",
+            phases=(
+                Phase(
+                    name="start",
+                    time_fraction=0.0,
+                    joint_targets={"hip_flexion": 0.0},
+                ),
+                Phase(
+                    name="end",
+                    time_fraction=1.0,
+                    joint_targets={"hip_flexion": 1.0},
+                ),
+            ),
+        )
+
+        result = interpolate_phases(objective, num_points=3, duration=1.0)
+
+        assert isinstance(result, TrajectoryResult)
+        assert result.converged is True
+        assert result.objective_value == pytest.approx(0.0)
+        assert result.iterations == 0
 
 
 class TestCreateMocoStudy:
@@ -143,3 +246,25 @@ class TestCreateMocoStudy:
         assert list(study["problem"]["coordinates"]) == list(
             study["initial_guess"]["coordinates"].keys()
         )
+
+    def test_unknown_exercise_raises_key_error(self) -> None:
+        """create_moco_study should propagate KeyError for unknown exercises."""
+        cfg = TrajectoryConfig(exercise_name="definitely_not_an_exercise")
+
+        with pytest.raises(KeyError, match="definitely_not_an_exercise"):
+            create_moco_study(cfg)
+
+    def test_initial_guess_time_starts_at_zero_and_ends_at_duration(self) -> None:
+        """Initial guess time axis must span [0, duration]."""
+        cfg = TrajectoryConfig(
+            exercise_name="squat",
+            duration=2.0,
+            num_mesh_points=5,
+        )
+
+        study = create_moco_study(cfg)
+
+        times = study["initial_guess"]["time"]
+        assert times[0] == pytest.approx(0.0)
+        assert times[-1] == pytest.approx(2.0)
+        assert len(times) == 5


### PR DESCRIPTION
## Summary
- Expanded `tests/unit/test_trajectory_optimizer.py` with additional happy-path, edge, and DbC tests for `TrajectoryConfig`, `interpolate_phases`, and `create_moco_study`.
- Expanded `tests/unit/test_limb_builders.py` with additional tests for `add_bilateral_limb`, `add_bilateral_ball_joint_limb`, and `add_bilateral_custom_joint_limb` covering happy paths, edge cases, and `zip(strict=True)` / `KeyError` contract enforcement.
- Updated SPEC.md Change Log (1.0.2) to reflect the test expansion.

Fixes #130

## Test plan
- [ ] CI `ruff check` passes
- [ ] CI `ruff format --check` passes
- [ ] CI `pytest` passes (tests are deterministic, rely on fixtures only)
- [ ] Coverage floor (>=80%) maintained