### PR TITLE
[codex] Reject non-finite OpenSim scalar contract values

### DIFF
--- a/src/opensim_models/shared/contracts/preconditions.py
+++ b/src/opensim_models/shared/contracts/preconditions.py
@@ -17,12 +17,14 @@ logger = logging.getLogger(__name__)
 
 def require_positive(value: float, name: str) -> None:
     """Require *value* to be strictly positive."""
+    require_finite(value, name)
     if value <= 0:
         raise ValueError(f"{name} must be positive, got {value}")
 
 
 def require_non_negative(value: float, name: str) -> None:
     """Require *value* >= 0."""
+    require_finite(value, name)
     if value < 0:
         raise ValueError(f"{name} must be non-negative, got {value}")
 
@@ -46,6 +48,7 @@ def require_finite(arr: ArrayLike, name: str) -> None:
 
 def require_in_range(value: float, low: float, high: float, name: str) -> None:
     """Require *low* <= *value* <= *high*."""
+    require_finite([value, low, high], name)
     if not (low <= value <= high):
         raise ValueError(f"{name} must be in [{low}, {high}], got {value}")
 

--- a/tests/unit/shared/test_preconditions.py
+++ b/tests/unit/shared/test_preconditions.py
@@ -26,6 +26,11 @@ class TestRequirePositive:
         with pytest.raises(ValueError, match="must be positive"):
             require_positive(-1.0, "x")
 
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_rejects_non_finite(self, value):
+        with pytest.raises(ValueError, match="non-finite"):
+            require_positive(value, "x")
+
 
 class TestRequireNonNegative:
     def test_accepts_zero(self):
@@ -37,6 +42,11 @@ class TestRequireNonNegative:
     def test_rejects_negative(self):
         with pytest.raises(ValueError, match="must be non-negative"):
             require_non_negative(-0.001, "x")
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_rejects_non_finite(self, value):
+        with pytest.raises(ValueError, match="non-finite"):
+            require_non_negative(value, "x")
 
 
 class TestRequireUnitVector:
@@ -89,6 +99,11 @@ class TestRequireInRange:
     def test_rejects_above(self):
         with pytest.raises(ValueError, match=r"must be in"):
             require_in_range(11.0, 0.0, 10.0, "x")
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_rejects_non_finite_value(self, value):
+        with pytest.raises(ValueError, match="non-finite"):
+            require_in_range(value, 0.0, 10.0, "x")
 
 
 class TestRequireShape:


### PR DESCRIPTION
## Summary
- Make shared scalar contract guards reject NaN and infinities directly.
- Add targeted precondition tests for non-finite positive, non-negative, and range values.

Closes #151

## Validation
- `TMPDIR=/tmp PYTHONPATH=src python3 -m pytest tests/unit/shared/test_preconditions.py -q -o addopts=''`
