### PR TITLE
chore(security): implement gitleaks and ruff security static analysis (clean rebase of #152)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,12 @@
 # =============================================================================
 
 repos:
+  # Gitleaks - Fast secrets scanning
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.2
+    hooks:
+      - id: gitleaks
+
   # Ruff - Fast Python linter with auto-fix
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.10


### PR DESCRIPTION
Clean rebase of #152 onto current `main`.

The original PR had three commits:
1. `chore: force self-hosted runners` — **dropped as obsolete**. Main already uses the fleet-aware `pick-runner` pattern (merged in #150). Forcing self-hosted would regress this.
2. `ci: fix pick-runner dispatcher to use ubuntu-latest` — dropped (main's pick-runner already correctly runs on `ubuntu-latest`).
3. `chore(security): gitleaks + ruff security analysis` — **kept and cherry-picked**. This is the actual security-scan addition to `.pre-commit-config.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)