### PR TITLE
fix(#151): reject NaN/inf in positive-value contract guards

### DIFF
--- a/src/opensim_models/optimization/trajectory_optimizer.py
+++ b/src/opensim_models/optimization/trajectory_optimizer.py
@@ -129,8 +129,8 @@ def interpolate_phases(
     """
     if num_points < 2:
         raise ValueError(f"num_points must be >= 2, got {num_points}")
-    if duration <= 0:
-        raise ValueError(f"duration must be > 0, got {duration}")
+    # require_positive rejects NaN / +/-inf as well as non-positive (issue #151).
+    require_positive(duration, "duration")
 
     time = np.linspace(0.0, duration, num_points)
     normalised = time / duration  # [0, 1]

--- a/src/opensim_models/shared/body/_segment_data.py
+++ b/src/opensim_models/shared/body/_segment_data.py
@@ -66,11 +66,12 @@ def _segment_radius_from_mass(mass: float, length: float) -> float:
         (square vs circle cross-section), which is intentional: the pelvis and
         torso are broader than a cylinder of equal mass and length.  This is a
         deliberate simplification, not a bug.
+
+    Rejects non-finite (NaN / +/-inf) and non-positive values via
+    ``require_positive`` (issue #151).
     """
-    if length <= 0:
-        raise ValueError(f"Segment length must be positive, got {length}")
-    if mass <= 0:
-        raise ValueError(f"Segment mass must be positive, got {mass}")
+    require_positive(length, "Segment length")
+    require_positive(mass, "Segment mass")
     volume = mass / _TISSUE_DENSITY_KG_M3
     return math.sqrt(volume / (math.pi * length))
 

--- a/src/opensim_models/shared/contracts/postconditions.py
+++ b/src/opensim_models/shared/contracts/postconditions.py
@@ -7,9 +7,15 @@ generation before they propagate to downstream XML or simulation.
 from __future__ import annotations
 
 import logging
+import math
 import xml.etree.ElementTree as ET
 
 logger = logging.getLogger(__name__)
+
+
+def _is_finite_positive(value: float) -> bool:
+    """Return True iff *value* is a finite float strictly > 0."""
+    return math.isfinite(value) and value > 0
 
 
 def ensure_valid_xml(xml_string: str) -> ET.Element:
@@ -49,21 +55,29 @@ def ensure_coordinates_within_bounds(root: ET.Element) -> None:
 
 
 def ensure_positive_mass(mass: float, body_name: str) -> None:
-    """Assert that a body's mass is positive after computation."""
-    if mass <= 0:
+    """Assert that a body's mass is finite and positive after computation.
+
+    Rejects NaN and +/-inf as well as non-positive values (issue #151).
+    """
+    if not _is_finite_positive(mass):
         raise ValueError(
-            f"Postcondition violated: {body_name} mass={mass} is not positive"
+            f"Postcondition violated: {body_name} mass={mass} is not a "
+            f"finite positive value"
         )
 
 
 def ensure_positive_definite_inertia(
     ixx: float, iyy: float, izz: float, body_name: str
 ) -> None:
-    """Assert that principal inertias are positive (necessary for PD)."""
+    """Assert that principal inertias are finite and positive (necessary for PD).
+
+    Rejects NaN and +/-inf as well as non-positive values (issue #151).
+    """
     for label, val in [("Ixx", ixx), ("Iyy", iyy), ("Izz", izz)]:
-        if val <= 0:
+        if not _is_finite_positive(val):
             raise ValueError(
-                f"Postcondition violated: {body_name} {label}={val} not positive"
+                f"Postcondition violated: {body_name} {label}={val} is not a "
+                f"finite positive value"
             )
     # Triangle inequality for principal inertias
     if ixx + iyy < izz or ixx + izz < iyy or iyy + izz < ixx:

--- a/src/opensim_models/shared/utils/contact_helpers.py
+++ b/src/opensim_models/shared/utils/contact_helpers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import xml.etree.ElementTree as ET
 
+from opensim_models.shared.contracts.preconditions import require_positive
 from opensim_models.shared.utils.xml_helpers import vec3_str
 
 logger = logging.getLogger(__name__)
@@ -47,9 +48,11 @@ def add_contact_sphere(
     location: tuple[float, float, float],
     radius: float = 0.02,
 ) -> ET.Element:
-    """Add a ContactSphere geometry for foot contact points."""
-    if radius <= 0:
-        raise ValueError(f"Contact sphere radius must be positive, got {radius}")
+    """Add a ContactSphere geometry for foot contact points.
+
+    Rejects non-finite (NaN / +/-inf) and non-positive radii (issue #151).
+    """
+    require_positive(radius, "Contact sphere radius")
     cg_set = model.find("ContactGeometrySet")
     if cg_set is None:
         cg_set = ET.SubElement(model, "ContactGeometrySet")

--- a/tests/unit/shared/test_body_model.py
+++ b/tests/unit/shared/test_body_model.py
@@ -21,6 +21,16 @@ class TestBodyModelSpec:
         with pytest.raises(ValueError, match="must be positive"):
             BodyModelSpec(height=-1.0)
 
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_rejects_non_finite_mass(self, value):
+        with pytest.raises(ValueError, match="non-finite"):
+            BodyModelSpec(total_mass=value)
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_rejects_non_finite_height(self, value):
+        with pytest.raises(ValueError, match="non-finite"):
+            BodyModelSpec(height=value)
+
     def test_frozen(self):
         spec = BodyModelSpec()
         with pytest.raises(AttributeError):

--- a/tests/unit/shared/test_ground_contact.py
+++ b/tests/unit/shared/test_ground_contact.py
@@ -71,6 +71,14 @@ class TestContactSphere:
                 model, name="bad", body="foot_l", location=(0, 0, 0), radius=0.0
             )
 
+    @pytest.mark.parametrize("radius", [float("nan"), float("inf"), float("-inf")])
+    def test_rejects_non_finite_radius(self, radius):
+        model = ET.Element("Model")
+        with pytest.raises(ValueError, match="non-finite"):
+            add_contact_sphere(
+                model, name="bad", body="foot_l", location=(0, 0, 0), radius=radius
+            )
+
     def test_has_location(self):
         model = ET.Element("Model")
         geom = add_contact_sphere(

--- a/tests/unit/shared/test_postconditions.py
+++ b/tests/unit/shared/test_postconditions.py
@@ -24,12 +24,17 @@ class TestEnsurePositiveMass:
         ensure_positive_mass(1.0, "body")
 
     def test_rejects_zero(self):
-        with pytest.raises(ValueError, match="not positive"):
+        with pytest.raises(ValueError, match="not a finite positive value"):
             ensure_positive_mass(0.0, "body")
 
     def test_rejects_negative(self):
-        with pytest.raises(ValueError, match="not positive"):
+        with pytest.raises(ValueError, match="not a finite positive value"):
             ensure_positive_mass(-5.0, "body")
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+    def test_rejects_non_finite(self, value):
+        with pytest.raises(ValueError, match="not a finite positive value"):
+            ensure_positive_mass(value, "body")
 
 
 class TestEnsurePositiveDefiniteInertia:
@@ -37,9 +42,21 @@ class TestEnsurePositiveDefiniteInertia:
         ensure_positive_definite_inertia(1.0, 1.0, 1.0, "body")
 
     def test_rejects_zero_component(self):
-        with pytest.raises(ValueError, match="not positive"):
+        with pytest.raises(ValueError, match="not a finite positive value"):
             ensure_positive_definite_inertia(0.0, 1.0, 1.0, "body")
 
     def test_rejects_triangle_inequality_violation(self):
         with pytest.raises(ValueError, match="triangle inequality"):
             ensure_positive_definite_inertia(0.1, 0.1, 100.0, "body")
+
+    @pytest.mark.parametrize(
+        "ixx,iyy,izz",
+        [
+            (float("nan"), 1.0, 1.0),
+            (1.0, float("inf"), 1.0),
+            (1.0, 1.0, float("-inf")),
+        ],
+    )
+    def test_rejects_non_finite_component(self, ixx, iyy, izz):
+        with pytest.raises(ValueError, match="not a finite positive value"):
+            ensure_positive_definite_inertia(ixx, iyy, izz, "body")

--- a/tests/unit/shared/test_segment_data.py
+++ b/tests/unit/shared/test_segment_data.py
@@ -1,0 +1,38 @@
+"""Tests for shared body segment data helpers.
+
+Guards ``_segment_radius_from_mass`` against non-finite (NaN / +/-inf) and
+non-positive mass/length inputs (issue #151).
+"""
+
+import math
+
+import pytest
+
+from opensim_models.shared.body._segment_data import _segment_radius_from_mass
+
+
+class TestSegmentRadiusFromMass:
+    def test_accepts_positive_inputs(self) -> None:
+        r = _segment_radius_from_mass(mass=5.0, length=0.3)
+        assert r > 0.0
+        assert math.isfinite(r)
+
+    @pytest.mark.parametrize("length", [0.0, -0.1])
+    def test_rejects_nonpositive_length(self, length: float) -> None:
+        with pytest.raises(ValueError, match="Segment length"):
+            _segment_radius_from_mass(mass=1.0, length=length)
+
+    @pytest.mark.parametrize("mass", [0.0, -2.0])
+    def test_rejects_nonpositive_mass(self, mass: float) -> None:
+        with pytest.raises(ValueError, match="Segment mass"):
+            _segment_radius_from_mass(mass=mass, length=0.3)
+
+    @pytest.mark.parametrize("length", [float("nan"), float("inf"), float("-inf")])
+    def test_rejects_non_finite_length(self, length: float) -> None:
+        with pytest.raises(ValueError, match="non-finite"):
+            _segment_radius_from_mass(mass=1.0, length=length)
+
+    @pytest.mark.parametrize("mass", [float("nan"), float("inf"), float("-inf")])
+    def test_rejects_non_finite_mass(self, mass: float) -> None:
+        with pytest.raises(ValueError, match="non-finite"):
+            _segment_radius_from_mass(mass=mass, length=0.3)

--- a/tests/unit/test_edge_cases.py
+++ b/tests/unit/test_edge_cases.py
@@ -100,7 +100,7 @@ class TestPostconditionEdgeCases:
             ensure_valid_xml("")
 
     def test_ensure_positive_mass_negative(self):
-        with pytest.raises(ValueError, match="not positive"):
+        with pytest.raises(ValueError, match="not a finite positive value"):
             ensure_positive_mass(-1.0, "test_body")
 
     def test_ensure_inertia_single_zero(self):

--- a/tests/unit/test_trajectory_optimizer.py
+++ b/tests/unit/test_trajectory_optimizer.py
@@ -115,6 +115,9 @@ class TestInterpolatePhases:
             (-3, 1.0, "num_points"),
             (4, 0.0, "duration"),
             (4, -0.5, "duration"),
+            (4, float("nan"), "non-finite"),
+            (4, float("inf"), "non-finite"),
+            (4, float("-inf"), "non-finite"),
         ],
     )
     def test_rejects_invalid_sampling_arguments(


### PR DESCRIPTION
## Summary

Closes #151. Four additional call sites still used bare `if x <= 0`
comparisons, which silently accept `NaN` (fails every comparison) and `+inf`.
PR #154 already tightened `require_positive` / `require_non_negative` in
`shared/contracts/preconditions.py`; this PR closes the remaining gaps the
audit enumerated.

## Functions fixed

| File | Function | Change |
| --- | --- | --- |
| `src/opensim_models/shared/body/_segment_data.py` | `_segment_radius_from_mass` | Mass and length now routed through `require_positive` (finite + > 0) |
| `src/opensim_models/shared/utils/contact_helpers.py` | `add_contact_sphere` | Radius routed through `require_positive` |
| `src/opensim_models/optimization/trajectory_optimizer.py` | `interpolate_phases` | Duration routed through `require_positive` |
| `src/opensim_models/shared/contracts/postconditions.py` | `ensure_positive_mass`, `ensure_positive_definite_inertia` | Added `math.isfinite` check via new `_is_finite_positive` helper; updated error message |

`BodyModelSpec.__post_init__` already delegates to `require_positive`, so the
tightening in #154 plus the audit fix above cascade to protect
`total_mass` and `height`.

## Tests added (TDD)

Parametrized NaN / +inf / -inf cases for every fixed guard:

- `tests/unit/shared/test_segment_data.py` (new file, 9 tests) — covers
  `_segment_radius_from_mass` for NaN/inf mass and length plus non-positive
  boundaries.
- `tests/unit/shared/test_body_model.py::TestBodyModelSpec` — 6 new
  parametrized cases covering `total_mass` and `height` NaN/+inf/-inf.
- `tests/unit/shared/test_ground_contact.py::TestContactSphere` — 3 new
  cases for contact-sphere radius NaN/+inf/-inf.
- `tests/unit/test_trajectory_optimizer.py::TestInterpolatePhases` —
  3 new parametrized rows for `duration` NaN/+inf/-inf.
- `tests/unit/shared/test_postconditions.py` — 3 new cases for
  `ensure_positive_mass` NaN/+inf/-inf and 3 more for
  `ensure_positive_definite_inertia` non-finite components.
- `tests/unit/test_edge_cases.py` — updated stale `match="not positive"`
  regex to the new `not a finite positive value` message.

### Local test output (50 relevant tests, 132 in shared+trajectory suites)

```
$ python3 -m pytest tests/unit/shared/test_segment_data.py \
    tests/unit/shared/test_postconditions.py \
    tests/unit/shared/test_body_model.py::TestBodyModelSpec \
    tests/unit/shared/test_ground_contact.py::TestContactSphere \
    tests/unit/test_trajectory_optimizer.py::TestInterpolatePhases::test_rejects_invalid_sampling_arguments
50 passed in 2.32s

$ python3 -m pytest -n auto -m "not slow and not requires_opensim" --no-cov
481 passed (2 pre-existing env-only ImportErrors for matplotlib + hypothesis, unrelated)
```

`ruff check` and `ruff format --check` pass on the full tree.

## Cross-repo follow-up (do NOT fix in this PR)

Grep of sibling fleet repos shows the same bare `if value <= 0` pattern in
`require_positive` (no `require_finite` call):

- `D-sorganization/Drake_Models` — `src/drake_models/shared/contracts/preconditions.py:16` (needs fix)
- `D-sorganization/Pinocchio_Models` — `src/pinocchio_models/shared/contracts/preconditions.py:24` (needs fix)
- `D-sorganization/MuJoCo_Models` — already calls `require_finite` first, OK.

Suggest opening mirror issues on Drake_Models and Pinocchio_Models for a
follow-up sprint.

## Test plan

- [x] `python3 -m pytest -n auto -m "not slow and not requires_opensim" --no-cov` green locally (481 passed)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [ ] CI `ruff check`
- [ ] CI `ruff format --check`
- [ ] CI `mypy src`
- [ ] CI `pytest` with 80% coverage floor
- [ ] `pip-audit` / `bandit`

Generated with [Claude Code](https://claude.com/claude-code)