### PR TITLE
chore(repo): scaffold fixes for comprehensive health assessment (#198)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,14 @@ updates:
       - "ci"
     commit-message:
       prefix: "chore(ci)"
+
+  - package-ecosystem: "cargo"
+    directory: "/rust_core"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "rust"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -21,6 +21,7 @@ permissions:
 
 jobs:
   pick-runner:
+    name: Pick Runner
     runs-on: d-sorg-fleet
     timeout-minutes: 5
     # Fail fast — if runner selection fails, nothing downstream should run.
@@ -34,6 +35,7 @@ jobs:
           GH_TOKEN: ${{ secrets.RUNNER_CHECK_TOKEN }}
         run: "ONLINE=$(gh api /orgs/${{ github.repository_owner }}/actions/runners \\\n  --jq '[.runners[] | select(.status == \"online\") | select(.labels[].name == \"d-sorg-fleet\")] | length' \\\n  2>/dev/null || echo \"0\")\nif [[ \"$ONLINE\" -gt 0 ]]; then\n  echo \"runner=d-sorg-fleet\" >> $GITHUB_OUTPUT\n  echo \"Self-hosted runner online — routing locally\"\nelse\n  echo \"runner=d-sorg-fleet\" >> $GITHUB_OUTPUT\n  echo \"No self-hosted runner — using local self-hosted\"\nfi"
   quality-gate:
+    name: Quality Gate
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 20
     steps:
@@ -126,6 +128,7 @@ jobs:
 
     needs: pick-runner
   rust-gate:
+    name: Rust Gate
     needs:
       - pick-runner
       - quality-gate
@@ -171,6 +174,7 @@ jobs:
         run: cargo test --manifest-path rust_core/Cargo.toml
 
   tests:
+    name: Tests (Python ${{ matrix.python }})
     needs:
       - pick-runner
       - quality-gate

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,13 @@ venv/
 .DS_Store
 Thumbs.db
 .hypothesis/
+
+# Benchmark results: ignore contents, keep directory with .gitkeep
 .benchmarks/
+!.benchmarks/
+.benchmarks/*
+!.benchmarks/.gitkeep
+
 *.osim
 
 # Stale root files (one-off scripts / debug artifacts)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# OpenSim Models Documentation
+
+This directory contains project documentation organized by topic.
+
+## Structure
+
+- `adr/` — Architecture Decision Records documenting significant technical decisions.
+- `architecture/` — High-level system architecture overviews and design documents.
+- `assessments/` — Periodic repository health assessments and audits.
+
+## Contributing
+
+See the top-level [`CONTRIBUTING.md`](../CONTRIBUTING.md) and [`AGENTS.md`](../AGENTS.md) for guidelines.


### PR DESCRIPTION
## Summary

Addresses quick-fix items from [EPIC] Comprehensive Repository Health Assessment 2026-04-26 (#198).

## Changes

- **Add `docs/README.md`** — Documents the purpose and structure of the `docs/` directory (ADR, architecture, assessments).
- **Add `.benchmarks/.gitkeep`** — Ensures the pytest-benchmark results directory is tracked in git, enabling future baseline persistence.
- **Update `.gitignore`** — Ignores benchmark result contents while preserving the `.gitkeep` file.
- **Add Cargo dependabot config** — Configures Dependabot for weekly `rust_core/Cargo.toml` updates, addressing P1-G002 (Rust dependencies not tracked by automated updates).
- **Add human-readable CI job names** — All jobs in `ci-standard.yml` now have explicit `name:` fields for better GitHub UI visibility.

## Test Plan

- [x] No runtime code changes; existing tests unaffected.
- [x] `git status` confirms `.benchmarks/.gitkeep` is tracked.
- [x] Workflow syntax validated locally with `grep` for `name:` fields.

## Related Issues

Closes #198 (partial — addresses scaffold/quick-fix items only; remaining P0/P1 findings tracked in their own issues).