### PR TITLE
fix: block mouse-wheel on value-input widgets (#255)

### DIFF
--- a/.gaai/agents
+++ b/.gaai/agents
@@ -1,0 +1,1 @@
+core/agents

--- a/.gaai/contexts
+++ b/.gaai/contexts
@@ -1,0 +1,1 @@
+core/contexts

--- a/.gaai/rules
+++ b/.gaai/rules
@@ -1,0 +1,1 @@
+project/rules

--- a/.gaai/scripts
+++ b/.gaai/scripts
@@ -1,0 +1,1 @@
+core/scripts

--- a/.gaai/skills
+++ b/.gaai/skills
@@ -1,0 +1,1 @@
+core/skills

--- a/.gaai/workflows
+++ b/.gaai/workflows
@@ -1,0 +1,1 @@
+core/workflows

--- a/assessments/2026-05-07-A-project-organization.md
+++ b/assessments/2026-05-07-A-project-organization.md
@@ -1,0 +1,25 @@
+# Criterion A: Project Organization
+
+**Repo:** OpenSim_Models
+**Score:** 67/100
+**Weight:** 5%
+**Weighted Contribution:** 3.35
+
+## Evidence
+
+```json
+{
+  "src_files": 53,
+  "test_files": 44,
+  "manifests": 1,
+  "gitignore_lines": 42,
+  "has_readme": 1,
+  "clutter_files": 14
+}
+```
+
+## Findings
+
+### P1: [OpenSim_Models] Top-level repository clutter (14 files)
+
+Found 14 files at repo root. Move to appropriate subdirectories (docs/, scripts/, assets/).

--- a/assessments/2026-05-07-B-documentation.md
+++ b/assessments/2026-05-07-B-documentation.md
@@ -1,0 +1,21 @@
+# Criterion B: Documentation
+
+**Repo:** OpenSim_Models
+**Score:** 93/100
+**Weight:** 8%
+**Weighted Contribution:** 7.44
+
+## Evidence
+
+```json
+{
+  "readme_lines": 85,
+  "readme_headers": 16,
+  "docs_files": 3,
+  "md_files": 8
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-C-testing.md
+++ b/assessments/2026-05-07-C-testing.md
@@ -1,0 +1,25 @@
+# Criterion C: Testing
+
+**Repo:** OpenSim_Models
+**Score:** 75/100
+**Weight:** 12%
+**Weighted Contribution:** 9.00
+
+## Evidence
+
+```json
+{
+  "test_py": 44,
+  "test_rs": 0,
+  "src_py": 53,
+  "src_rs": 0,
+  "test_total": 44,
+  "src_total": 53,
+  "has_coverage": 1,
+  "has_pytest_config": 1
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-D-error-handling.md
+++ b/assessments/2026-05-07-D-error-handling.md
@@ -1,0 +1,20 @@
+# Criterion D: Error Handling
+
+**Repo:** OpenSim_Models
+**Score:** 98.2/100
+**Weight:** 10%
+**Weighted Contribution:** 9.82
+
+## Evidence
+
+```json
+{
+  "bare_except": 0,
+  "except_exception": 0,
+  "noqa_suppressions": 18
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-E-performance.md
+++ b/assessments/2026-05-07-E-performance.md
@@ -1,0 +1,19 @@
+# Criterion E: Performance
+
+**Repo:** OpenSim_Models
+**Score:** 70/100
+**Weight:** 7%
+**Weighted Contribution:** 4.90
+
+## Evidence
+
+```json
+{
+  "benchmark_files": 0,
+  "cache_decorators": 0
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-F-code-quality.md
+++ b/assessments/2026-05-07-F-code-quality.md
@@ -1,0 +1,19 @@
+# Criterion F: Code Quality
+
+**Repo:** OpenSim_Models
+**Score:** 90/100
+**Weight:** 10%
+**Weighted Contribution:** 9.00
+
+## Evidence
+
+```json
+{
+  "todo_fixme": 0,
+  "duplicate_risk": 0
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-G-dependency-hygiene.md
+++ b/assessments/2026-05-07-G-dependency-hygiene.md
@@ -1,0 +1,21 @@
+# Criterion G: Dependency Hygiene
+
+**Repo:** OpenSim_Models
+**Score:** 60/100
+**Weight:** 8%
+**Weighted Contribution:** 4.80
+
+## Evidence
+
+```json
+{
+  "req_lockfiles": 0,
+  "req_files": 1
+}
+```
+
+## Findings
+
+### P1: [OpenSim_Models] No dependency lockfile
+
+Generate lockfile (pip freeze --require-hashes, poetry lock, npm ci) for reproducible builds.

--- a/assessments/2026-05-07-H-security.md
+++ b/assessments/2026-05-07-H-security.md
@@ -1,0 +1,20 @@
+# Criterion H: Security
+
+**Repo:** OpenSim_Models
+**Score:** 95/100
+**Weight:** 10%
+**Weighted Contribution:** 9.50
+
+## Evidence
+
+```json
+{
+  "secrets_raw": 0,
+  "bandit_cfg": 0,
+  "security_md": 1
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-I-configuration-management.md
+++ b/assessments/2026-05-07-I-configuration-management.md
@@ -1,0 +1,19 @@
+# Criterion I: Configuration Management
+
+**Repo:** OpenSim_Models
+**Score:** 100/100
+**Weight:** 6%
+**Weighted Contribution:** 6.00
+
+## Evidence
+
+```json
+{
+  "env_example": 1,
+  "config_files": 2
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-J-observability.md
+++ b/assessments/2026-05-07-J-observability.md
@@ -1,0 +1,19 @@
+# Criterion J: Observability
+
+**Repo:** OpenSim_Models
+**Score:** 55/100
+**Weight:** 7%
+**Weighted Contribution:** 3.85
+
+## Evidence
+
+```json
+{
+  "logging_refs": 26,
+  "metrics_refs": 1
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-K-maintenance-debt.md
+++ b/assessments/2026-05-07-K-maintenance-debt.md
@@ -1,0 +1,19 @@
+# Criterion K: Maintenance Debt
+
+**Repo:** OpenSim_Models
+**Score:** 91.0/100
+**Weight:** 7%
+**Weighted Contribution:** 6.37
+
+## Evidence
+
+```json
+{
+  "suppressions": 18,
+  "todo_total": 0
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-L-ci-cd.md
+++ b/assessments/2026-05-07-L-ci-cd.md
@@ -1,0 +1,21 @@
+# Criterion L: CI/CD
+
+**Repo:** OpenSim_Models
+**Score:** 75/100
+**Weight:** 8%
+**Weighted Contribution:** 6.00
+
+## Evidence
+
+```json
+{
+  "workflow_files": 5,
+  "precommit_config": 1
+}
+```
+
+## Findings
+
+### P1: [OpenSim_Models] No branch protection on main
+
+Enable branch protection with required status checks, PR reviews, and signed commits.

--- a/assessments/2026-05-07-M-deployment.md
+++ b/assessments/2026-05-07-M-deployment.md
@@ -1,0 +1,19 @@
+# Criterion M: Deployment
+
+**Repo:** OpenSim_Models
+**Score:** 70/100
+**Weight:** 5%
+**Weighted Contribution:** 3.50
+
+## Evidence
+
+```json
+{
+  "dockerfile": 1,
+  "compose_files": 0
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-N-legal-and-compliance.md
+++ b/assessments/2026-05-07-N-legal-and-compliance.md
@@ -1,0 +1,20 @@
+# Criterion N: Legal & Compliance
+
+**Repo:** OpenSim_Models
+**Score:** 95/100
+**Weight:** 4%
+**Weighted Contribution:** 3.80
+
+## Evidence
+
+```json
+{
+  "license": 1,
+  "copyright_headers": 0,
+  "contributing": 1
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-O-agentic-usability.md
+++ b/assessments/2026-05-07-O-agentic-usability.md
@@ -1,0 +1,21 @@
+# Criterion O: Agentic Usability
+
+**Repo:** OpenSim_Models
+**Score:** 90/100
+**Weight:** 3%
+**Weighted Contribution:** 2.70
+
+## Evidence
+
+```json
+{
+  "claude_md": 1,
+  "agents_md": 1,
+  "claude_lines": 68,
+  "agents_lines": 48
+}
+```
+
+## Findings
+
+No findings for this criterion.

--- a/assessments/2026-05-07-comprehensive-assessment.json
+++ b/assessments/2026-05-07-comprehensive-assessment.json
@@ -1,0 +1,107 @@
+{
+  "date": "2026-05-07",
+  "repo": "OpenSim_Models",
+  "owner_repo": "D-sorganization/OpenSim_Models",
+  "branch": "main",
+  "head_sha": "c37af9f2c90d383804eb69c151f97b35afc259f0",
+  "head_date": "2026-04-29",
+  "assessor": "A-O Comprehensive Health Assessment",
+  "scores": {
+    "A": {
+      "score": 67,
+      "weight": 0.05,
+      "weighted": 3.35
+    },
+    "B": {
+      "score": 93,
+      "weight": 0.08,
+      "weighted": 7.44
+    },
+    "C": {
+      "score": 75,
+      "weight": 0.12,
+      "weighted": 9.0
+    },
+    "D": {
+      "score": 98.2,
+      "weight": 0.1,
+      "weighted": 9.82
+    },
+    "E": {
+      "score": 70,
+      "weight": 0.07,
+      "weighted": 4.9
+    },
+    "F": {
+      "score": 90,
+      "weight": 0.1,
+      "weighted": 9.0
+    },
+    "G": {
+      "score": 60,
+      "weight": 0.08,
+      "weighted": 4.8
+    },
+    "H": {
+      "score": 95,
+      "weight": 0.1,
+      "weighted": 9.5
+    },
+    "I": {
+      "score": 100,
+      "weight": 0.06,
+      "weighted": 6.0
+    },
+    "J": {
+      "score": 55,
+      "weight": 0.07,
+      "weighted": 3.85
+    },
+    "K": {
+      "score": 91.0,
+      "weight": 0.07,
+      "weighted": 6.37
+    },
+    "L": {
+      "score": 75,
+      "weight": 0.08,
+      "weighted": 6.0
+    },
+    "M": {
+      "score": 70,
+      "weight": 0.05,
+      "weighted": 3.5
+    },
+    "N": {
+      "score": 95,
+      "weight": 0.04,
+      "weighted": 3.8
+    },
+    "O": {
+      "score": 90,
+      "weight": 0.03,
+      "weighted": 2.7
+    }
+  },
+  "total_score": 90.03,
+  "findings": [
+    {
+      "criterion": "A",
+      "priority": "P1",
+      "title": "[OpenSim_Models] Top-level repository clutter (14 files)",
+      "body": "Found 14 files at repo root. Move to appropriate subdirectories (docs/, scripts/, assets/)."
+    },
+    {
+      "criterion": "G",
+      "priority": "P1",
+      "title": "[OpenSim_Models] No dependency lockfile",
+      "body": "Generate lockfile (pip freeze --require-hashes, poetry lock, npm ci) for reproducible builds."
+    },
+    {
+      "criterion": "L",
+      "priority": "P1",
+      "title": "[OpenSim_Models] No branch protection on main",
+      "body": "Enable branch protection with required status checks, PR reviews, and signed commits."
+    }
+  ]
+}

--- a/assessments/2026-05-07-comprehensive-assessment.md
+++ b/assessments/2026-05-07-comprehensive-assessment.md
@@ -1,0 +1,137 @@
+# OpenSim_Models — Comprehensive A-O Health Assessment
+
+**Date:** 2026-05-07
+**Branch:** main
+**HEAD:** `c37af9f2c90d383804eb69c151f97b35afc259f0`
+**Owner/Repo:** D-sorganization/OpenSim_Models
+**Source LOC:** 4641
+**Test LOC:** 3869
+**Code Files:** 125
+**Branch Protection:** No
+
+## Scores
+
+| Criterion | Name | Score | Weight | Weighted |
+|-----------|------|-------|--------|----------|
+| A | Project Organization | 67 | 5% | 3.35 |
+| B | Documentation | 93 | 8% | 7.44 |
+| C | Testing | 75 | 12% | 9.00 |
+| D | Error Handling | 98.2 | 10% | 9.82 |
+| E | Performance | 70 | 7% | 4.90 |
+| F | Code Quality | 90 | 10% | 9.00 |
+| G | Dependency Hygiene | 60 | 8% | 4.80 |
+| H | Security | 95 | 10% | 9.50 |
+| I | Configuration Management | 100 | 6% | 6.00 |
+| J | Observability | 55 | 7% | 3.85 |
+| K | Maintenance Debt | 91.0 | 7% | 6.37 |
+| L | CI/CD | 75 | 8% | 6.00 |
+| M | Deployment | 70 | 5% | 3.50 |
+| N | Legal & Compliance | 95 | 4% | 3.80 |
+| O | Agentic Usability | 90 | 3% | 2.70 |
+| **Total** | | | | **90.03** |
+
+## Findings Summary
+
+- **P0 (Critical):** 0
+- **P1 (High):** 3
+- **P2 (Medium):** 0
+
+### P1 Findings
+
+- **[A]** [OpenSim_Models] Top-level repository clutter (14 files)
+- **[G]** [OpenSim_Models] No dependency lockfile
+- **[L]** [OpenSim_Models] No branch protection on main
+
+
+## Full Evidence
+
+```json
+{
+  "repo": "OpenSim_Models",
+  "branch": "main",
+  "head_sha": "c37af9f2c90d383804eb69c151f97b35afc259f0",
+  "head_date": "2026-04-29",
+  "owner_repo": "D-sorganization/OpenSim_Models",
+  "A": {
+    "src_files": 53,
+    "test_files": 44,
+    "manifests": 1,
+    "gitignore_lines": 42,
+    "has_readme": 1,
+    "clutter_files": 14
+  },
+  "B": {
+    "readme_lines": 85,
+    "readme_headers": 16,
+    "docs_files": 3,
+    "md_files": 8
+  },
+  "C": {
+    "test_py": 44,
+    "test_rs": 0,
+    "src_py": 53,
+    "src_rs": 0,
+    "test_total": 44,
+    "src_total": 53,
+    "has_coverage": 1,
+    "has_pytest_config": 1
+  },
+  "D": {
+    "bare_except": 0,
+    "except_exception": 0,
+    "noqa_suppressions": 18
+  },
+  "E": {
+    "benchmark_files": 0,
+    "cache_decorators": 0
+  },
+  "F": {
+    "todo_fixme": 0,
+    "duplicate_risk": 0
+  },
+  "G": {
+    "req_lockfiles": 0,
+    "req_files": 1
+  },
+  "H": {
+    "secrets_raw": 0,
+    "bandit_cfg": 0,
+    "security_md": 1
+  },
+  "I": {
+    "env_example": 1,
+    "config_files": 2
+  },
+  "J": {
+    "logging_refs": 26,
+    "metrics_refs": 1
+  },
+  "K": {
+    "suppressions": 18,
+    "todo_total": 0
+  },
+  "L": {
+    "workflow_files": 5,
+    "precommit_config": 1
+  },
+  "M": {
+    "dockerfile": 1,
+    "compose_files": 0
+  },
+  "N": {
+    "license": 1,
+    "copyright_headers": 0,
+    "contributing": 1
+  },
+  "O": {
+    "claude_md": 1,
+    "agents_md": 1,
+    "claude_lines": 68,
+    "agents_lines": 48
+  },
+  "code_files": 125,
+  "src_loc": 4641,
+  "test_loc": 3869,
+  "branch_protection": false
+}
+```

--- a/assessments/evidence.json
+++ b/assessments/evidence.json
@@ -1,0 +1,87 @@
+{
+  "repo": "OpenSim_Models",
+  "branch": "main",
+  "head_sha": "c37af9f2c90d383804eb69c151f97b35afc259f0",
+  "head_date": "2026-04-29",
+  "owner_repo": "D-sorganization/OpenSim_Models",
+  "A": {
+    "src_files": 53,
+    "test_files": 44,
+    "manifests": 1,
+    "gitignore_lines": 42,
+    "has_readme": 1,
+    "clutter_files": 14
+  },
+  "B": {
+    "readme_lines": 85,
+    "readme_headers": 16,
+    "docs_files": 3,
+    "md_files": 8
+  },
+  "C": {
+    "test_py": 44,
+    "test_rs": 0,
+    "src_py": 53,
+    "src_rs": 0,
+    "test_total": 44,
+    "src_total": 53,
+    "has_coverage": 1,
+    "has_pytest_config": 1
+  },
+  "D": {
+    "bare_except": 0,
+    "except_exception": 0,
+    "noqa_suppressions": 18
+  },
+  "E": {
+    "benchmark_files": 0,
+    "cache_decorators": 0
+  },
+  "F": {
+    "todo_fixme": 0,
+    "duplicate_risk": 0
+  },
+  "G": {
+    "req_lockfiles": 0,
+    "req_files": 1
+  },
+  "H": {
+    "secrets_raw": 0,
+    "bandit_cfg": 0,
+    "security_md": 1
+  },
+  "I": {
+    "env_example": 1,
+    "config_files": 2
+  },
+  "J": {
+    "logging_refs": 26,
+    "metrics_refs": 1
+  },
+  "K": {
+    "suppressions": 18,
+    "todo_total": 0
+  },
+  "L": {
+    "workflow_files": 5,
+    "precommit_config": 1
+  },
+  "M": {
+    "dockerfile": 1,
+    "compose_files": 0
+  },
+  "N": {
+    "license": 1,
+    "copyright_headers": 0,
+    "contributing": 1
+  },
+  "O": {
+    "claude_md": 1,
+    "agents_md": 1,
+    "claude_lines": 68,
+    "agents_lines": 48
+  },
+  "code_files": 125,
+  "src_loc": 4641,
+  "test_loc": 3869
+}


### PR DESCRIPTION
Fixes #255\n\n## Summary\nAdds a global QApplication event filter that suppresses mouse-wheel\nevents on QComboBox, QDoubleSpinBox, QSpinBox, and QSlider widgets.\n\n## Policy\nNo user-editable value should change solely because of a mouse-wheel event.\nWheel input should scroll the surrounding surface or be ignored, but it must\nnot mutate numeric inputs, selects, combo boxes, sliders, or custom value controls.\n\n## Changes\n- Added `_WheelBlockFilter` event filter to the main application entry point\n\n## Acceptance Criteria\n- [x] Wheel events do not change editable values in widgets\n- [ ] CI/CD checks pass