### PR TITLE
fix(rust): update to current numpy crate API

### DIFF
--- a/rust_core/src/dynamics.rs
+++ b/rust_core/src/dynamics.rs
@@ -4,7 +4,7 @@
 //! suitable for rigid-body chains.
 
 use ndarray::{Array1, Array2};
-use numpy::{IntoPyArrayBound, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
+use numpy::{IntoPyArray, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
@@ -101,7 +101,7 @@ pub fn inverse_dynamics_batch<'py>(
         result.row_mut(i).assign(row);
     }
 
-    Ok(result.into_pyarray_bound(py).into())
+    Ok(result.into_pyarray(py).into())
 }
 
 // ---------------------------------------------------------------------------

--- a/rust_core/src/interpolation.rs
+++ b/rust_core/src/interpolation.rs
@@ -3,7 +3,7 @@
 //! Parallel linear interpolation of waypoint values over a normalised time grid.
 
 use ndarray::{Array1, Array2};
-use numpy::{IntoPyArrayBound, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
+use numpy::{IntoPyArray, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
@@ -81,7 +81,7 @@ pub fn interpolate_phases_rs<'py>(
         result.column_mut(c).assign(col);
     }
 
-    Ok(result.into_pyarray_bound(py).into())
+    Ok(result.into_pyarray(py).into())
 }
 
 // ---------------------------------------------------------------------------

--- a/rust_core/src/kinematics.rs
+++ b/rust_core/src/kinematics.rs
@@ -3,7 +3,7 @@
 //! Parallel batch center-of-mass (COM) computation across segment positions.
 
 use ndarray::Array2;
-use numpy::{IntoPyArrayBound, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
+use numpy::{IntoPyArray, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
 use pyo3::prelude::*;
 use rayon::prelude::*;
 
@@ -61,7 +61,7 @@ pub fn com_batch<'py>(
         }
     }
 
-    Ok(result.into_pyarray_bound(py).into())
+    Ok(result.into_pyarray(py).into())
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The numpy Rust crate renamed IntoPyArrayBound→IntoPyArray and into_pyarray_bound→into_pyarray. This update fixes the Rust Gate CI failure on main, unblocking PRs that inherit it (e.g. #257).