### PR TITLE
chore(testing): adopt fleet testing standards Phase 1 (#260)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,31 @@
-"""Root conftest for pytest -- shared fixtures across all test modules."""
+"""Root conftest for pytest -- shared fixtures across all test modules.
+
+Per Fleet Testing Standards §5, set thread-safety and headless env vars
+before any heavy import. See:
+https://github.com/D-sorganization/Repository_Management/blob/main/docs/FLEET_TESTING_STANDARDS.md
+"""
 
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET
+import os
 
-import pytest
+# C-extension thread safety. Many "xdist worker crashed" failures
+# come from MKL/OpenBLAS forking under xdist. Pin to single-threaded
+# for tests; production code can re-thread itself if it needs to.
+os.environ.setdefault("OMP_NUM_THREADS", "1")
+os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+os.environ.setdefault("MKL_NUM_THREADS", "1")
+os.environ.setdefault("NUMEXPR_NUM_THREADS", "1")
+
+# matplotlib headless backend, set before any matplotlib import.
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+# Qt headless backend, for repos that import PyQt/PySide indirectly.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import xml.etree.ElementTree as ET  # noqa: E402
+
+import pytest  # noqa: E402
 
 from opensim_models.exercises.base import ExerciseConfig
 from opensim_models.shared.barbell import BarbellSpec

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,12 +90,46 @@ pythonpath = [".", "src"]
 python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
-addopts = "-ra -q --strict-markers --strict-config --durations=20 -n auto --dist loadscope"
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+timeout = 60
+timeout_method = "thread"
+
+# Default lane: fast, deterministic, offline.
+# See https://github.com/D-sorganization/Repository_Management/blob/main/docs/FLEET_TESTING_STANDARDS.md
+addopts = """
+  -ra
+  -q
+  --strict-markers
+  --strict-config
+  --durations=20
+  -n auto
+  --dist loadscope
+  -m "not slow and not live_simulation and not e2e and not requires_network"
+"""
+
 markers = [
-    "slow: marks tests as slow",
-    "integration: marks tests as integration tests",
-    "unit: marks tests as unit tests",
-    "requires_opensim: tests requiring opensim package",
+    # ---- tier markers ----
+    "unit: pure logic, fully mocked, < 100 ms wall-clock",
+    "integration: cross-module / file-system / process boundaries, < 5 s",
+    "e2e: full-stack smoke tests; nightly + release gate only",
+    "slow: > 1 s wall-clock; deselect with -m 'not slow'",
+    "live_simulation: requires a real physics / math engine; deselect by default",
+
+    # ---- environment markers ----
+    "requires_network: needs real outbound network; deselect by default",
+    "requires_gpu: needs CUDA / Metal / ROCm",
+    "requires_gl: needs OpenGL or a display",
+    "headless_safe: verified under QT_QPA_PLATFORM=offscreen",
+
+    # ---- per-engine markers ----
+    "requires_opensim: skip when import opensim fails",
+    "requires_matlab: skip when MATLAB Engine for Python is unavailable",
+
+    # ---- workflow markers ----
+    "serial: must run with -n 0 (xdist parallel breaks this test)",
+    "benchmark: deterministic perf smoke; not a primary correctness gate",
+    "smoke: release-blocking smoke; subset of e2e",
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",


### PR DESCRIPTION
## Summary

Phase 1 of fleet testing alignment per FLEET_TESTING_STANDARDS.md (additive).

- Merge §2 `[tool.pytest.ini_options]` block: full tier marker set (unit/integration/e2e/slow/live_simulation), environment markers (requires_network/gpu/gl/headless_safe), per-engine markers including **`requires_opensim`** and `requires_matlab`, and workflow markers (serial/benchmark/smoke).
- Default lane deselects `slow + live_simulation + e2e + requires_network`.
- `timeout=60` (thread method), asyncio defaults.
- `conftest.py` sets §5 thread-safety env vars (OMP/OPENBLAS/MKL/NUMEXPR_NUM_THREADS=1) and headless backends (MPLBACKEND=Agg, QT_QPA_PLATFORM=offscreen) before any heavy import.
- No coverage gate change (data/fixtures repo).

Closes #260. Refs EPIC D-sorganization/Repository_Management#1140.

## Test plan

- [x] `pytest --collect-only -q` passes (528 tests collected, no errors)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)