### PR TITLE
ci(standard): parallelize jobs after pick-runner + fail-fast: false on matrix

### DIFF
--- a/.github/workflows/ci-standard.yml
+++ b/.github/workflows/ci-standard.yml
@@ -143,7 +143,6 @@ jobs:
     name: Rust Gate
     needs:
       - pick-runner
-      - quality-gate
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 15
     steps:
@@ -189,7 +188,6 @@ jobs:
     name: Tests (Python ${{ matrix.python }})
     needs:
       - pick-runner
-      - quality-gate
       - rust-gate
     runs-on: ${{ needs.pick-runner.outputs.runner }}
     timeout-minutes: 25


### PR DESCRIPTION
Part of 2026-05-17 fleet CI parallelization campaign (15/15 complete with this PR). Pattern: jobs flattened from `needs: [pick-runner, quality-gate]` to `needs: pick-runner` since `quality-gate` declares no `outputs:` and no downstream step consumes its outputs. Matrix `fail-fast: false` added so all matrix entries report failures independently. Failure-visibility benefit: agents remediating failing PRs see ALL failures on the first run instead of one-fix-at-a-time across multiple queue cycles.

## Changes
- `rust-gate`: dropped `quality-gate` from `needs:`
- `tests`: dropped `quality-gate` from `needs:` (still gated on `rust-gate`)
- `tests` matrix already had `fail-fast: false` — preserved
- `quality-gate-compat` and `tests-311-compat` shims preserved (branch-ruleset required-check compatibility)